### PR TITLE
SEO completo: i18n, cases, blog e performance

### DIFF
--- a/app/[locale]/blog/[slug]/page.tsx
+++ b/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getBlogPost, getBlogSlugs } from "../../../src/content/blog";
+import { buildPageMetadata } from "../../../src/constants/metadata";
+import {
+  absoluteUrl,
+  isLocale,
+  LOCALES,
+  localizedPath,
+  SITE_NAME,
+} from "../../../src/constants/seo";
+import { styles } from "../../../src/styles";
+
+type BlogPostPageProps = {
+  params: Promise<{ locale: string; slug: string }>;
+};
+
+export function generateStaticParams() {
+  return LOCALES.flatMap((locale) =>
+    getBlogSlugs().map((slug) => ({ locale, slug })),
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPostPageProps): Promise<Metadata> {
+  const { locale: localeParam, slug } = await params;
+  if (!isLocale(localeParam)) {
+    return {};
+  }
+  const post = getBlogPost(slug);
+  if (!post) {
+    return {};
+  }
+  const copy = post.locales[localeParam];
+  return buildPageMetadata({
+    locale: localeParam,
+    path: `/blog/${slug}`,
+    title: `${copy.title} | ${SITE_NAME}`,
+    description: copy.description,
+    ogType: "article",
+  });
+}
+
+export default async function BlogPostPage({ params }: Readonly<BlogPostPageProps>) {
+  const { locale: localeParam, slug } = await params;
+  if (!isLocale(localeParam)) {
+    notFound();
+  }
+
+  const post = getBlogPost(slug);
+  if (!post) {
+    notFound();
+  }
+
+  const locale = localeParam;
+  const copy = post.locales[locale];
+  const backLabel = locale === "pt" ? "Voltar ao blog" : "Back to blog";
+
+  const articleSchema = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: copy.title,
+    description: copy.description,
+    datePublished: post.date,
+    author: {
+      "@type": "Person",
+      name: SITE_NAME,
+    },
+    url: absoluteUrl(locale, `/blog/${slug}`),
+    inLanguage: locale === "pt" ? "pt-BR" : "en-US",
+  };
+
+  return (
+    <main className="min-h-screen bg-primary px-6 pb-20 pt-28 text-white sm:px-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href={localizedPath(locale, "/blog")}
+          className="text-sm text-secondary transition-colors hover:text-white"
+        >
+          ← {backLabel}
+        </Link>
+        <time
+          dateTime={post.date}
+          className="mt-6 block text-xs uppercase tracking-wide text-secondary"
+        >
+          {post.date}
+        </time>
+        <h1 className={`${styles.sectionHeadText} mt-2`}>{copy.title}</h1>
+        <p className="mt-4 text-base text-secondary">{copy.description}</p>
+        <div className="mt-8 space-y-10 text-base leading-7 text-white-100">
+          {copy.sections.map((section) => (
+            <section
+              key={section.heading ?? section.paragraphs[0]?.slice(0, 32)}
+              className="space-y-4"
+            >
+              {section.heading ? (
+                <h2 className="text-xl font-semibold text-white sm:text-2xl">
+                  {section.heading}
+                </h2>
+              ) : null}
+              {section.paragraphs.map((paragraph) => (
+                <p key={paragraph.slice(0, 40)} className="text-secondary">
+                  {paragraph}
+                </p>
+              ))}
+            </section>
+          ))}
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { blogPosts } from "../../src/content/blog";
+import { buildPageMetadata } from "../../src/constants/metadata";
+import {
+  isLocale,
+  LOCALES,
+  localizedPath,
+} from "../../src/constants/seo";
+import { styles } from "../../src/styles";
+
+type BlogIndexProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export function generateStaticParams() {
+  return LOCALES.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: BlogIndexProps): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  if (!isLocale(localeParam)) {
+    return {};
+  }
+
+  const title = "Blog | Kaique Simão";
+  const description =
+    localeParam === "pt"
+      ? "Ensaios sobre sistemas críticos, SaaS, Flutter em produção e o equilíbrio entre 3D, SEO e performance — escritos a partir da trajetória full-stack."
+      : "Essays on mission-critical systems, SaaS, production Flutter, and balancing 3D, SEO, and performance — drawn from a full-stack career path.";
+
+  return buildPageMetadata({
+    locale: localeParam,
+    path: "/blog",
+    title,
+    description,
+  });
+}
+
+export default async function BlogIndexPage({ params }: Readonly<BlogIndexProps>) {
+  const { locale: localeParam } = await params;
+  if (!isLocale(localeParam)) {
+    notFound();
+  }
+
+  const locale = localeParam;
+  const heading = "Blog";
+  const intro =
+    locale === "pt"
+      ? "Textos mais longos sobre a pressão de sistemas industriais, SaaS multi-tenant, Flutter em produção e as decisões por trás deste portfólio 3D."
+      : "Longer pieces on industrial-system pressure, multi-tenant SaaS, production Flutter, and the decisions behind this 3D portfolio.";
+  const backLabel = locale === "pt" ? "Voltar ao portfólio" : "Back to portfolio";
+
+  return (
+    <main className="min-h-screen bg-primary px-6 pb-20 pt-28 text-white sm:px-16">
+      <div className="mx-auto max-w-3xl">
+        <Link
+          href={localizedPath(locale)}
+          className="text-sm text-secondary transition-colors hover:text-white"
+        >
+          ← {backLabel}
+        </Link>
+        <h1 className={`${styles.sectionHeadText} mt-6`}>{heading}</h1>
+        <p className="mt-3 text-secondary">{intro}</p>
+        <ul className="mt-10 space-y-6">
+          {blogPosts.map((post) => {
+            const copy = post.locales[locale];
+            return (
+              <li key={post.slug}>
+                <Link
+                  href={localizedPath(locale, `/blog/${post.slug}`)}
+                  className="block rounded-xl border border-white/10 p-5 transition-colors hover:border-[#915EFF]/50"
+                >
+                  <time
+                    dateTime={post.date}
+                    className="text-xs uppercase tracking-wide text-secondary"
+                  >
+                    {post.date}
+                  </time>
+                  <h2 className="mt-2 text-xl font-semibold text-white">
+                    {copy.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-secondary">
+                    {copy.description}
+                  </p>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import I18nProvider from "../src/components/I18nProvider";
+import JsonLd from "../src/components/JsonLd";
+import Navbar from "../src/components/Navbar";
+import { buildPageMetadata } from "../src/constants/metadata";
+import { isLocale, LOCALES, Locale } from "../src/constants/seo";
+
+type LocaleLayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+};
+
+export function generateStaticParams() {
+  return LOCALES.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  if (!isLocale(localeParam)) {
+    return {};
+  }
+  return buildPageMetadata({ locale: localeParam });
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: Readonly<LocaleLayoutProps>) {
+  const { locale: localeParam } = await params;
+  if (!isLocale(localeParam)) {
+    notFound();
+  }
+
+  const locale: Locale = localeParam;
+
+  return (
+    <>
+      <JsonLd locale={locale} />
+      <I18nProvider locale={locale} />
+      <Navbar />
+      {children}
+    </>
+  );
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,5 @@
+import App from "../src/App";
+
+export default function HomePage() {
+  return <App />;
+}

--- a/app/[locale]/projects/[slug]/page.tsx
+++ b/app/[locale]/projects/[slug]/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { buildPageMetadata } from "../../../src/constants/metadata";
+import { translate } from "../../../src/constants/i18n-server";
+import {
+  getProjectBySlug,
+  getProjectSlugs,
+} from "../../../src/constants/projects";
+import { getCaseStudy } from "../../../src/content/case-studies";
+import {
+  absoluteUrl,
+  isLocale,
+  LOCALES,
+  localizedPath,
+  SITE_NAME,
+  SITE_URL,
+} from "../../../src/constants/seo";
+import { styles } from "../../../src/styles";
+
+type ProjectPageProps = {
+  params: Promise<{ locale: string; slug: string }>;
+};
+
+export function generateStaticParams() {
+  return LOCALES.flatMap((locale) =>
+    getProjectSlugs().map((slug) => ({ locale, slug })),
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: ProjectPageProps): Promise<Metadata> {
+  const { locale: localeParam, slug } = await params;
+  if (!isLocale(localeParam)) {
+    return {};
+  }
+  const project = getProjectBySlug(slug);
+  if (!project) {
+    return {};
+  }
+
+  const caseStudyCopy = getCaseStudy(slug, localeParam);
+  const title = `${translate(localeParam, project.nameKey)} | ${SITE_NAME}`;
+  const description =
+    caseStudyCopy?.summary ?? translate(localeParam, project.descriptionKey);
+
+  return buildPageMetadata({
+    locale: localeParam,
+    path: `/projects/${slug}`,
+    title,
+    description,
+  });
+}
+
+export default async function ProjectPage({
+  params,
+}: Readonly<ProjectPageProps>) {
+  const { locale: localeParam, slug } = await params;
+  if (!isLocale(localeParam)) {
+    notFound();
+  }
+
+  const project = getProjectBySlug(slug);
+  if (!project) {
+    notFound();
+  }
+
+  const locale = localeParam;
+  const name = translate(locale, project.nameKey);
+  const description = translate(locale, project.descriptionKey);
+  const caseStudyCopy = getCaseStudy(slug, locale);
+  const backLabel = locale === "pt" ? "Voltar ao portfólio" : "Back to portfolio";
+  const viewDemo = locale === "pt" ? "Ver demo" : "View demo";
+  const viewSource = locale === "pt" ? "Código-fonte" : "Source code";
+  const caseStudyLabel =
+    locale === "pt" ? "Case study empresarial" : "Enterprise case study";
+  const contextLabel = locale === "pt" ? "Contexto" : "Context";
+  const outcomesLabel =
+    locale === "pt" ? "O que o produto entrega" : "What the product delivers";
+  const engineeringLabel =
+    locale === "pt" ? "Sinais de engenharia" : "Engineering signals";
+
+  const creativeWork = {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name,
+    description: caseStudyCopy?.summary ?? description,
+    url: absoluteUrl(locale, `/projects/${slug}`),
+    image: `${SITE_URL}${project.image}`,
+    author: {
+      "@type": "Person",
+      name: SITE_NAME,
+    },
+    keywords: project.tags.map((tag) => tag.name).join(", "),
+  };
+
+  return (
+    <main className="min-h-screen bg-primary px-6 pb-20 pt-28 text-white sm:px-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(creativeWork) }}
+      />
+      <div className="mx-auto max-w-4xl">
+        <Link
+          href={localizedPath(locale)}
+          className="text-sm text-secondary transition-colors hover:text-white"
+        >
+          ← {backLabel}
+        </Link>
+
+        <div className="relative mt-8 aspect-16/10 w-full overflow-hidden rounded-2xl">
+          <Image
+            src={project.image}
+            alt={name}
+            fill
+            priority
+            sizes="(max-width: 896px) 100vw, 896px"
+            className="object-cover"
+          />
+        </div>
+
+        {project.isCaseStudy ? (
+          <p className="mt-6 text-sm font-semibold uppercase tracking-wide text-[#915EFF]">
+            {caseStudyLabel}
+          </p>
+        ) : null}
+
+        <h1 className={`${styles.sectionHeadText} mt-2`}>{name}</h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-secondary sm:text-lg">
+          {caseStudyCopy?.summary ?? description}
+        </p>
+
+        {caseStudyCopy ? (
+          <div className="mt-10 space-y-10">
+            <section>
+              <h2 className="text-lg font-semibold text-white">{contextLabel}</h2>
+              <p className="mt-3 text-base leading-7 text-secondary">
+                {caseStudyCopy.context}
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold text-white">
+                {outcomesLabel}
+              </h2>
+              <ul className="mt-3 list-disc space-y-2 pl-5 text-base leading-7 text-secondary">
+                {caseStudyCopy.outcomes.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold text-white">
+                {engineeringLabel}
+              </h2>
+              <ul className="mt-3 list-disc space-y-2 pl-5 text-base leading-7 text-secondary">
+                {caseStudyCopy.engineering.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </section>
+
+            <p className="rounded-xl border border-white/10 bg-tertiary/50 px-4 py-3 text-sm leading-6 text-secondary">
+              {caseStudyCopy.note}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-wrap gap-2">
+          {project.tags.map((tag) => (
+            <span key={tag.name} className={`text-sm ${tag.color}`}>
+              #{tag.name}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-4">
+          {project.demo_link ? (
+            <a
+              href={project.demo_link}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-lg bg-[#915EFF] px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            >
+              {viewDemo}
+            </a>
+          ) : null}
+          {project.source_code_link ? (
+            <a
+              href={project.source_code_link}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-lg border border-white/20 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:border-white/50"
+            >
+              {viewSource}
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,13 +3,11 @@ import { Poppins } from "next/font/google";
 import "./globals.css";
 import "react-phone-number-input/style.css";
 import "react-vertical-timeline-component/style.min.css";
-import JsonLd from "./src/components/JsonLd";
 import {
-  PAGE_DESCRIPTION,
   PAGE_TITLE,
-  SEO_KEYWORDS,
   SITE_NAME,
   SITE_URL,
+  seoByLocale,
 } from "./src/constants/seo";
 
 const poppins = Poppins({
@@ -18,29 +16,15 @@ const poppins = Poppins({
   display: "swap",
 });
 
+const googleVerification = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  keywords: SEO_KEYWORDS,
+  description: seoByLocale.pt.description,
+  applicationName: SITE_NAME,
   authors: [{ name: SITE_NAME, url: SITE_URL }],
   creator: SITE_NAME,
-  alternates: {
-    canonical: "/",
-  },
-  openGraph: {
-    type: "website",
-    locale: "pt_BR",
-    url: SITE_URL,
-    siteName: SITE_NAME,
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
   robots: {
     index: true,
     follow: true,
@@ -48,7 +32,12 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.svg",
     shortcut: "/favicon.svg",
+    apple: "/logo.svg",
   },
+  manifest: "/manifest.webmanifest",
+  ...(googleVerification
+    ? { verification: { google: googleVerification } }
+    : {}),
 };
 
 export default function RootLayout({
@@ -57,11 +46,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="pt" dir="ltr" suppressHydrationWarning>
-      <body className={poppins.className}>
-        <JsonLd />
-        {children}
-      </body>
+    <html lang="pt" dir="ltr" suppressHydrationWarning data-scroll-behavior="smooth">
+      <body className={poppins.className}>{children}</body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,14 @@ import { Poppins } from "next/font/google";
 import "./globals.css";
 import "react-phone-number-input/style.css";
 import "react-vertical-timeline-component/style.min.css";
+import JsonLd from "./src/components/JsonLd";
+import {
+  PAGE_DESCRIPTION,
+  PAGE_TITLE,
+  SEO_KEYWORDS,
+  SITE_NAME,
+  SITE_URL,
+} from "./src/constants/seo";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -11,9 +19,32 @@ const poppins = Poppins({
 });
 
 export const metadata: Metadata = {
-  title: "Kaique Simão | Software Engineer",
-  description:
-    "Software Engineer full-stack — sistemas críticos, SaaS multi-tenant, cloud e experiências web modernas.",
+  metadataBase: new URL(SITE_URL),
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  keywords: SEO_KEYWORDS,
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
   icons: {
     icon: "/favicon.svg",
     shortcut: "/favicon.svg",
@@ -27,7 +58,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt" dir="ltr" suppressHydrationWarning>
-      <body className={poppins.className}>{children}</body>
+      <body className={poppins.className}>
+        <JsonLd />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { SITE_NAME, SITE_URL } from "./src/constants/seo";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: "Kaique",
+    description:
+      "Software Engineer full-stack — sistemas críticos, SaaS, cloud e web moderna.",
+    start_url: "/pt",
+    display: "standalone",
+    background_color: "#050816",
+    theme_color: "#050816",
+    icons: [
+      {
+        src: "/logo.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+    ],
+    lang: "pt-BR",
+    id: SITE_URL,
+  };
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,105 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Kaique Simão | Software Engineer";export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px 72px",
+          background: "linear-gradient(135deg, #050816 0%, #100d25 45%, #151030 100%)",
+          color: "#f3f3f3",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+          }}
+        >
+          <div
+            style={{
+              width: "18px",
+              height: "18px",
+              borderRadius: "999px",
+              background: "#915EFF",
+            }}
+          />
+          <div
+            style={{
+              fontSize: "28px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "#aaa6c3",
+            }}
+          >
+            Portfolio
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "18px" }}>
+          <div
+            style={{
+              fontSize: "72px",
+              fontWeight: 700,
+              lineHeight: 1.05,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Kaique Simão
+          </div>
+          <div
+            style={{
+              fontSize: "36px",
+              fontWeight: 500,
+              color: "#915EFF",
+            }}
+          >
+            Software Engineer
+          </div>
+          <div
+            style={{
+              maxWidth: "820px",
+              fontSize: "26px",
+              lineHeight: 1.4,
+              color: "#aaa6c3",
+            }}
+          >
+            Full-stack · sistemas críticos · SaaS · cloud · experiências web
+            modernas
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: "22px",
+            color: "#aaa6c3",
+          }}
+        >
+          <span>portfolio.kaique.site</span>
+          <div
+            style={{
+              width: "160px",
+              height: "4px",
+              borderRadius: "999px",
+              background: "linear-gradient(90deg, #915EFF 0%, transparent 100%)",
+            }}
+          />
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,9 +1,17 @@
 import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
-export const alt = "Kaique Simão | Software Engineer";export const size = { width: 1200, height: 630 };
+export const alt = "Kaique Simão | Software Engineer";
+export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default function OpenGraphImage() {
+export default async function OpenGraphImage() {
+  const screenshotBuffer = await readFile(
+    join(process.cwd(), "public/assets/projects/portfolio3d.png"),
+  );
+  const screenshotSrc = `data:image/png;base64,${screenshotBuffer.toString("base64")}`;
+
   return new ImageResponse(
     (
       <div
@@ -11,10 +19,7 @@ export default function OpenGraphImage() {
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          padding: "64px 72px",
-          background: "linear-gradient(135deg, #050816 0%, #100d25 45%, #151030 100%)",
+          background: "linear-gradient(135deg, #050816 0%, #100d25 50%, #151030 100%)",
           color: "#f3f3f3",
           fontFamily: "system-ui, sans-serif",
         }}
@@ -22,81 +27,158 @@ export default function OpenGraphImage() {
         <div
           style={{
             display: "flex",
-            alignItems: "center",
-            gap: "16px",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            width: "58%",
+            padding: "56px 56px 56px 64px",
           }}
         >
-          <div
-            style={{
-              width: "18px",
-              height: "18px",
-              borderRadius: "999px",
-              background: "#915EFF",
-            }}
-          />
-          <div
-            style={{
-              fontSize: "28px",
-              letterSpacing: "0.08em",
-              textTransform: "uppercase",
-              color: "#aaa6c3",
-            }}
-          >
-            Portfolio
+          <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
+            <div
+              style={{
+                width: "48px",
+                height: "54px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "12px",
+                background: "linear-gradient(160deg, #6936f5 0%, #915EFF 100%)",
+                color: "#ffffff",
+                fontSize: "22px",
+                fontWeight: 700,
+                letterSpacing: "-0.04em",
+              }}
+            >
+              KS
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "2px",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "22px",
+                  fontWeight: 600,
+                  color: "#f3f3f3",
+                }}
+              >
+                Kaique Simão
+              </div>
+              <div
+                style={{
+                  fontSize: "16px",
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                  color: "#aaa6c3",
+                }}
+              >
+                Portfolio 3D
+              </div>
+            </div>
           </div>
-        </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: "18px" }}>
-          <div
-            style={{
-              fontSize: "72px",
-              fontWeight: 700,
-              lineHeight: 1.05,
-              letterSpacing: "-0.02em",
-            }}
-          >
-            Kaique Simão
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+            <div
+              style={{
+                fontSize: "58px",
+                fontWeight: 700,
+                lineHeight: 1.05,
+                letterSpacing: "-0.03em",
+              }}
+            >
+              Software Engineer
+            </div>
+            <div
+              style={{
+                fontSize: "26px",
+                lineHeight: 1.35,
+                color: "#aaa6c3",
+                maxWidth: "520px",
+              }}
+            >
+              Full-stack · sistemas críticos · SaaS multi-tenant · cloud
+            </div>
+            <div
+              style={{
+                display: "flex",
+                gap: "10px",
+                marginTop: "8px",
+              }}
+            >
+              {["Next.js", "Three.js", "Spring", "Flutter"].map((label) => (
+                <div
+                  key={label}
+                  style={{
+                    fontSize: "16px",
+                    color: "#c4b5fd",
+                    border: "1px solid rgba(145, 94, 255, 0.45)",
+                    borderRadius: "999px",
+                    padding: "6px 14px",
+                  }}
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
           </div>
+
           <div
             style={{
-              fontSize: "36px",
-              fontWeight: 500,
-              color: "#915EFF",
-            }}
-          >
-            Software Engineer
-          </div>
-          <div
-            style={{
-              maxWidth: "820px",
-              fontSize: "26px",
-              lineHeight: 1.4,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              fontSize: "20px",
               color: "#aaa6c3",
             }}
           >
-            Full-stack · sistemas críticos · SaaS · cloud · experiências web
-            modernas
+            <span>portfolio.kaique.site</span>
+            <div
+              style={{
+                width: "120px",
+                height: "4px",
+                borderRadius: "999px",
+                background: "linear-gradient(90deg, #915EFF 0%, transparent 100%)",
+              }}
+            />
           </div>
         </div>
 
         <div
           style={{
             display: "flex",
-            justifyContent: "space-between",
             alignItems: "center",
-            fontSize: "22px",
-            color: "#aaa6c3",
+            justifyContent: "center",
+            width: "42%",
+            padding: "48px 48px 48px 0",
           }}
         >
-          <span>portfolio.kaique.site</span>
           <div
             style={{
-              width: "160px",
-              height: "4px",
-              borderRadius: "999px",
-              background: "linear-gradient(90deg, #915EFF 0%, transparent 100%)",
+              display: "flex",
+              width: "100%",
+              height: "100%",
+              borderRadius: "24px",
+              overflow: "hidden",
+              border: "1px solid rgba(145, 94, 255, 0.35)",
+              boxShadow: "0 24px 80px rgba(0, 0, 0, 0.45)",
             }}
-          />
+          >
+            {/* Brand preview — local PNG encoded for ImageResponse */}
+            <img
+              src={screenshotSrc}
+              alt=""
+              width={480}
+              height={534}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
+          </div>
         </div>
       </div>
     ),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,0 @@
-import App from "./src/App";
-
-export default function Home() {
-  return <App />;
-}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "./src/constants/seo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,13 +1,56 @@
 import type { MetadataRoute } from "next";
-import { SITE_URL } from "./src/constants/seo";
+import { blogPosts } from "./src/content/blog";
+import { getProjectSlugs } from "./src/constants/projects";
+import { LOCALES, SITE_URL, absoluteUrl } from "./src/constants/seo";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: SITE_URL,
-      lastModified: new Date(),
+  const lastModified = new Date();
+  const entries: MetadataRoute.Sitemap = [];
+
+  for (const locale of LOCALES) {
+    entries.push({
+      url: absoluteUrl(locale),
+      lastModified,
       changeFrequency: "monthly",
       priority: 1,
-    },
-  ];
+      alternates: {
+        languages: {
+          pt: absoluteUrl("pt"),
+          en: absoluteUrl("en"),
+        },
+      },
+    }, {
+      url: absoluteUrl(locale, "/blog"),
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    });
+
+    for (const slug of getProjectSlugs()) {
+      entries.push({
+        url: absoluteUrl(locale, `/projects/${slug}`),
+        lastModified,
+        changeFrequency: "monthly",
+        priority: 0.7,
+      });
+    }
+
+    for (const post of blogPosts) {
+      entries.push({
+        url: absoluteUrl(locale, `/blog/${post.slug}`),
+        lastModified: new Date(post.date),
+        changeFrequency: "yearly",
+        priority: 0.6,
+      });
+    }
+  }
+
+  entries.unshift({
+    url: SITE_URL,
+    lastModified,
+    changeFrequency: "monthly",
+    priority: 1,
+  });
+
+  return entries;
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "./src/constants/seo";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,6 @@
 import dynamic from "next/dynamic";
 import { useEffect, useState, useSyncExternalStore } from "react";
 import Hero from "./components/Hero";
-import Navbar from "./components/Navbar";
 import MobileContext from "./contexts/MobileContext.tsx";
 import i18n from "./i18n";
 
@@ -84,13 +83,14 @@ const App = () => {
     <MobileContext.Provider value={isMobile}>
       <div className={"relative z-0 overflow-x-hidden bg-primary"}>
         {shouldShowStars ? <StarsCanvas /> : null}
-        <Navbar />
-        <Hero />
-        <About />
-        <Experience />
-        <Tech />
-        <Projects />
-        <Contact />
+        <main>
+          <Hero />
+          <About />
+          <Experience />
+          <Tech />
+          <Projects />
+          <Contact />
+        </main>
       </div>
     </MobileContext.Provider>
   );

--- a/app/src/assets/index.ts
+++ b/app/src/assets/index.ts
@@ -21,10 +21,10 @@ const kotlin = "/assets/tech/kotlin.png";
 const android = "/assets/tech/android.png";
 const flutter = "/assets/tech/flutter.png";
 const postgre = "/assets/tech/postgre.png";
-const aws = "/assets/tech/aws.png?v=3";
-const azure = "/assets/tech/azure.png?v=3";
-const gcp = "/assets/tech/gcp.png?v=3";
-const cloudflare = "/assets/tech/cloudflare.png?v=3";
+const aws = "/assets/tech/aws.png";
+const azure = "/assets/tech/azure.png";
+const gcp = "/assets/tech/gcp.png";
+const cloudflare = "/assets/tech/cloudflare.png";
 
 const siemens = "/assets/company/siemens.png";
 const innomotics = "/assets/company/innomotics.png";

--- a/app/src/assets/locales/translations/en.ts
+++ b/app/src/assets/locales/translations/en.ts
@@ -1,7 +1,11 @@
 const en = {
   page_title: "Kaique Simão | Software Engineer",
   country_img: "Image of the Brazilian flag",
+  country_img_en: "Image of the United States flag",
   change_language: "Click here to change the language",
+  menu_open: "Open menu",
+  menu_close: "Close menu",
+  blog: "Blog",
   about: "About",
   work: "Experience",
   projects: "Projects",
@@ -54,19 +58,19 @@ const en = {
     "A selection of public projects and enterprise case studies. Corporate cases describe domain and impact without exposing internal details or public demos.",
   project_1_name: "3D Portfolio",
   project_1_description:
-    "Interactive portfolio built with Next.js and Three.js, featuring a 3D experience, i18n, and a clear presentation of career path and technical stack.",
+    "This site: a 3D Next.js landing with Three.js, PT/EN i18n, project pages, SEO (OG, sitemap, JSON-LD), and Cloudflare Workers deploy. Built to impress and still be indexable.",
   project_4_name: "PokeData",
   project_4_description:
-    "Flutter app (Android and Web) with a full Pokédex, regions, favorites, Firebase auth, and Play Store release.",
+    "Flutter app (Android + Web) with Pokédex, regions, favorites, and Firebase Auth — guest mode, Play Store, and Wasm web at pokedata.kaique.site with Cloudflare Pages CI/CD.",
   project_talenthub_name: "TalentHub",
   project_talenthub_description:
-    "Enterprise case study: multi-tenant SaaS platform for talent workflows and internal operations, focused on scalability and a modern web experience.",
+    "Enterprise case study: multi-tenant SaaS for talent and HR — tenant isolation, scalability, and modern web UX as product requirements. Great talking point for SaaS architecture; details and demos are not public.",
   project_videowall_name: "Videowall",
   project_videowall_description:
-    "Enterprise case study (Innomotics): control-tower for industrial KPIs and logistics, with alerts and Azure AD — Vue, Java/Spring, and PostgreSQL.",
+    "Enterprise case study (Innomotics): industrial control-tower videowall. Plant and logistics dashboards with severity status, configurable alerts, and Kanban incident handling — from signal to team action. Vue 3, Spring Boot, PostgreSQL, and Microsoft SSO.",
   project_iloa_name: "iLoA",
   project_iloa_description:
-    "Enterprise case study (Innomotics): corporate web app for managing project authority limits, with approval workflows on Java/Spring, Vue, and Azure.",
+    "Enterprise case study (Innomotics): Limit of Authority for industrial project governance. Unifies approvals, compliance, and questionnaires into one digital flow with SSO — instead of fragmented cross-team processes. Vue 3, Spring Boot, and Azure.",
   case_study_badge: "Case study",
   contact_success: "Thank you for reaching out. I'll get back to you shortly.",
   contact_error:

--- a/app/src/assets/locales/translations/pt.ts
+++ b/app/src/assets/locales/translations/pt.ts
@@ -1,7 +1,11 @@
 const pt = {
   page_title: "Kaique Simão | Software Engineer",
   country_img: "Imagem da bandeira do Brasil",
+  country_img_en: "Imagem da bandeira dos Estados Unidos",
   change_language: "Clique aqui para mudar o idioma",
+  menu_open: "Abrir menu",
+  menu_close: "Fechar menu",
+  blog: "Blog",
   about: "Sobre",
   work: "Experiência",
   projects: "Projetos",
@@ -54,19 +58,19 @@ const pt = {
     "Seleção de projetos públicos e cases empresariais. Os cases corporativos descrevem domínio e impacto sem expor detalhes internos nem demos públicas.",
   project_1_name: "Portfólio 3D",
   project_1_description:
-    "Portfólio interativo em Next.js e Three.js, com experiência 3D, i18n e apresentação da trajetória e stack técnica.",
+    "Este site: landing 3D em Next.js com Three.js, i18n PT/EN, páginas de projetos, SEO (OG, sitemap, JSON-LD) e deploy em Cloudflare Workers. Feito para impressionar e ainda ser indexável.",
   project_4_name: "PokeData",
   project_4_description:
-    "App Flutter (Android e Web) com Pokédex, regiões, favoritos, autenticação Firebase e publicação na Play Store.",
+    "App Flutter (Android + Web) com Pokédex, regiões, favoritos e Firebase Auth — modo convidado, Play Store e web Wasm em pokedata.kaique.site com CI/CD no Cloudflare Pages.",
   project_talenthub_name: "TalentHub",
   project_talenthub_description:
-    "Case empresarial: plataforma SaaS multi-tenant voltada a processos de talentos e operações internas, com foco em escalabilidade e experiência web moderna.",
+    "Case empresarial: SaaS multi-tenant para talentos e RH — isolamento por cliente, escalabilidade e UX web moderna como requisitos de produto. Ideal para conversar sobre arquitetura SaaS; detalhes e demos não são públicos.",
   project_videowall_name: "Videowall",
   project_videowall_description:
-    "Case empresarial (Innomotics): torre de controle com KPIs industriais e logística, alertas e Azure AD — Vue, Java/Spring e PostgreSQL.",
+    "Case empresarial (Innomotics): torre de controle industrial em videowall. Painéis de plantas e logística com status por severidade, alertas configuráveis e Kanban de ocorrências — do sinal à ação da equipe. Vue 3, Spring Boot, PostgreSQL e SSO Microsoft.",
   project_iloa_name: "iLoA",
   project_iloa_description:
-    "Case empresarial (Innomotics): aplicação web corporativa para gestão de limites de autoridade em projetos, com workflows de aprovação e stack Java/Spring, Vue e Azure.",
+    "Case empresarial (Innomotics): Limit of Authority para governança de projetos industriais. Unifica aprovações, compliance e questionários num fluxo digital com SSO — no lugar de processos fragmentados entre áreas. Vue 3, Spring Boot e Azure.",
   case_study_badge: "Case study",
   contact_success: "Obrigado pelo contato. Responderei em breve.",
   contact_error:

--- a/app/src/components/ComputerSection.tsx
+++ b/app/src/components/ComputerSection.tsx
@@ -1,11 +1,59 @@
-import { ComputerCanvas } from "./canvas";
+"use client";
+
+import dynamic from "next/dynamic";
+import { memo, useContext, useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { memo } from "react";
+import MobileContext from "../contexts/MobileContext";
+
+const ComputerCanvas = dynamic(
+  () => import("./canvas").then((mod) => mod.ComputerCanvas),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden={true}
+        className="h-64 w-full animate-pulse rounded-2xl bg-tertiary/40 sm:h-96"
+      />
+    ),
+  },
+);
 
 const ComputerSection = memo(() => {
+  const isMobile = useContext(MobileContext);
+  const [showCanvas, setShowCanvas] = useState(false);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setShowCanvas(true);
+      return;
+    }
+
+    // Defer WebGL on mobile so the hero text can win LCP.
+    if (typeof globalThis.window.requestIdleCallback === "function") {
+      const idleId = globalThis.window.requestIdleCallback(
+        () => setShowCanvas(true),
+        { timeout: 2500 },
+      );
+      return () => globalThis.window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = globalThis.window.setTimeout(() => {
+      setShowCanvas(true);
+    }, 1200);
+
+    return () => globalThis.window.clearTimeout(timeoutId);
+  }, [isMobile]);
+
   return (
     <section>
-      <ComputerCanvas />
+      {showCanvas ? (
+        <ComputerCanvas />
+      ) : (
+        <div
+          aria-hidden={true}
+          className="h-64 w-full animate-pulse rounded-2xl bg-tertiary/40 sm:h-96"
+        />
+      )}
       <div
         className={
           "absolute bottom-0 flex w-full items-center justify-center xs:-bottom-16"

--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from "react-i18next";
 
 const ComputerSection = dynamic(() => import("./ComputerSection"), {
   ssr: false,
-  loading: () => <div aria-hidden={true} className={"h-64 w-full sm:h-96"} />,
+  loading: () => (
+    <div
+      aria-hidden={true}
+      className={"h-64 w-full animate-pulse rounded-2xl bg-tertiary/40 sm:h-96"}
+    />
+  ),
 });
 
 const HeroSection = () => {

--- a/app/src/components/I18nProvider.tsx
+++ b/app/src/components/I18nProvider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import i18n from "../i18n";
+import type { Locale } from "../constants/seo";
+
+type I18nProviderProps = {
+  locale: Locale;
+};
+
+export default function I18nProvider({ locale }: I18nProviderProps) {
+  useEffect(() => {
+    if (i18n.language !== locale) {
+      void i18n.changeLanguage(locale);
+    }
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return null;
+}

--- a/app/src/components/JsonLd.tsx
+++ b/app/src/components/JsonLd.tsx
@@ -1,31 +1,58 @@
 import {
-  PAGE_DESCRIPTION,
+  absoluteUrl,
+  Locale,
+  LOCALE_SCHEMA,
   PAGE_TITLE,
   SITE_NAME,
   SITE_URL,
   SOCIAL_PROFILES,
+  seoByLocale,
 } from "../constants/seo";
+import { translate } from "../constants/i18n-server";
+import { projects } from "../constants/projects";
 
-const personSchema = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: SITE_NAME,
-  jobTitle: "Software Engineer",
-  url: SITE_URL,
-  sameAs: [...SOCIAL_PROFILES],
-  description: PAGE_DESCRIPTION,
+type JsonLdProps = {
+  locale: Locale;
 };
 
-const websiteSchema = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  name: PAGE_TITLE,
-  url: SITE_URL,
-  description: PAGE_DESCRIPTION,
-  inLanguage: "pt-BR",
-};
+export default function JsonLd({ locale }: Readonly<JsonLdProps>) {
+  const description = seoByLocale[locale].description;
 
-export default function JsonLd() {
+  const personSchema = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: SITE_NAME,
+    jobTitle: "Software Engineer",
+    url: absoluteUrl(locale),
+    sameAs: [...SOCIAL_PROFILES],
+    description,
+  };
+
+  const websiteSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: PAGE_TITLE,
+    url: SITE_URL,
+    description,
+    inLanguage: LOCALE_SCHEMA[locale],
+  };
+
+  const itemListSchema = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name:
+      locale === "pt"
+        ? "Projetos de Kaique Simão"
+        : "Kaique Simão projects",
+    itemListElement: projects.map((project, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: absoluteUrl(locale, `/projects/${project.slug}`),
+      name: translate(locale, project.nameKey),
+      description: translate(locale, project.descriptionKey),
+    })),
+  };
+
   return (
     <>
       <script
@@ -35,6 +62,10 @@ export default function JsonLd() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
       />
     </>
   );

--- a/app/src/components/JsonLd.tsx
+++ b/app/src/components/JsonLd.tsx
@@ -1,0 +1,41 @@
+import {
+  PAGE_DESCRIPTION,
+  PAGE_TITLE,
+  SITE_NAME,
+  SITE_URL,
+  SOCIAL_PROFILES,
+} from "../constants/seo";
+
+const personSchema = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: SITE_NAME,
+  jobTitle: "Software Engineer",
+  url: SITE_URL,
+  sameAs: [...SOCIAL_PROFILES],
+  description: PAGE_DESCRIPTION,
+};
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: PAGE_TITLE,
+  url: SITE_URL,
+  description: PAGE_DESCRIPTION,
+  inLanguage: "pt-BR",
+};
+
+export default function JsonLd() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+      />
+    </>
+  );
+}

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -1,33 +1,57 @@
+"use client";
+
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
 import { styles } from "../styles";
 import { languages, navLinks } from "../constants";
 import { brasil, close, logo, menu, usa } from "../assets";
 import { useTranslation } from "react-i18next";
+import {
+  DEFAULT_LOCALE,
+  isLocale,
+  Locale,
+  localizedPath,
+} from "../constants/seo";
 
 const Navbar = () => {
   const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
   const [active, setActive] = useState("");
   const [toggle, setToggle] = useState(true);
 
-  const handleLanguageChange = async (language: {
+  const pathSegments = pathname.split("/").filter(Boolean);
+  const localeSegment = pathSegments[0];
+  const currentLocale: Locale = isLocale(localeSegment)
+    ? localeSegment
+    : DEFAULT_LOCALE;
+  const pathWithoutLocale =
+    pathSegments.length > 1 ? `/${pathSegments.slice(1).join("/")}` : "";
+  const isHome = pathWithoutLocale === "";
+
+  const handleLanguageChange = (language: {
     nativeName: string;
     code: string;
   }) => {
-    try {
-      return await i18n.changeLanguage(language.code);
-    } catch (error) {
-      return console.error(error);
+    if (!isLocale(language.code)) {
+      return;
     }
+    const nextPath = localizedPath(language.code, pathWithoutLocale || "/");
+    void i18n.changeLanguage(language.code);
+    router.replace(nextPath);
   };
 
   const countryImgStyleClass = (language: string) =>
     `box-border size-9 cursor-pointer object-contain ${
-      i18n.resolvedLanguage === language
+      currentLocale === language || i18n.resolvedLanguage === language
         ? "rounded-full border-2 border-white"
         : ""
     }`;
+
+  const homeHref = localizedPath(currentLocale);
+  const blogHref = localizedPath(currentLocale, "/blog");
 
   return (
     <nav
@@ -39,20 +63,23 @@ const Navbar = () => {
         }
       >
         <Link
-          href={"/"}
+          href={homeHref}
           className={
             "flex min-w-0 max-w-[calc(100%-2.75rem)] items-center gap-2 sm:max-w-none"
           }
           onClick={() => {
             setActive("");
-            window.scrollTo(0, 0);
+            if (isHome) {
+              window.scrollTo(0, 0);
+            }
           }}
         >
           <Image
             src={logo}
-            alt={"logo"}
+            alt={t("hero_title")}
             width={36}
             height={36}
+            priority
             className={"size-9 shrink-0 object-contain"}
           />
           <p
@@ -65,21 +92,30 @@ const Navbar = () => {
           </p>
         </Link>
 
-        {/* desktop — visibility via CSS so SSR and client stay in sync */}
-        <ul className={"hidden list-none flex-row gap-10 sm:flex"}>
-          {navLinks.map((link) => (
-            <li
-              key={link.id}
-              className={`${active === link.id ? "text-white" : "text-secondary"} cursor-pointer text-lg font-medium hover:text-white`}
-              onClickCapture={() => setActive(link.id)}
-            >
-              <a href={`#${link.id}`}>{t(link.title)}</a>
-            </li>
-          ))}
+        <ul className={"hidden list-none flex-row items-center gap-10 sm:flex"}>
+          {isHome
+            ? navLinks.map((link) => (
+                <li
+                  key={link.id}
+                  className={`${active === link.id ? "text-white" : "text-secondary"} cursor-pointer text-lg font-medium hover:text-white`}
+                  onClickCapture={() => setActive(link.id)}
+                >
+                  <a href={`#${link.id}`}>{t(link.title)}</a>
+                </li>
+              ))
+            : null}
+          <li
+            className={`${active === "blog" ? "text-white" : "text-secondary"} cursor-pointer text-lg font-medium hover:text-white`}
+          >
+            <Link href={blogHref} onClick={() => setActive("blog")}>
+              {t("blog")}
+            </Link>
+          </li>
 
           <button
+            type="button"
             onClick={() => {
-              void handleLanguageChange(languages.portuguese);
+              handleLanguageChange(languages.portuguese);
             }}
           >
             <Image
@@ -92,13 +128,14 @@ const Navbar = () => {
             />
           </button>
           <button
+            type="button"
             onClick={() => {
-              void handleLanguageChange(languages.english);
+              handleLanguageChange(languages.english);
             }}
           >
             <Image
               src={usa}
-              alt={t("country_img")}
+              alt={t("country_img_en")}
               width={36}
               height={36}
               className={countryImgStyleClass(languages.english.code)}
@@ -107,12 +144,11 @@ const Navbar = () => {
           </button>
         </ul>
 
-        {/* mobile — visibility via CSS so SSR and client stay in sync */}
         <div className={"flex shrink-0 items-center justify-end sm:hidden"}>
           <div className="relative size-7">
             <Image
               src={menu}
-              alt={"menu"}
+              alt={t("menu_open")}
               width={28}
               height={28}
               className={`absolute size-7 transition-opacity duration-500 ${toggle ? "opacity-100" : "opacity-0"} cursor-pointer object-contain`}
@@ -120,7 +156,7 @@ const Navbar = () => {
             />
             <Image
               src={close}
-              alt={"close"}
+              alt={t("menu_close")}
               width={28}
               height={28}
               className={`size-7 transition-opacity duration-500 ${toggle ? "opacity-0" : "opacity-100"} cursor-pointer object-contain`}
@@ -135,22 +171,38 @@ const Navbar = () => {
                 "flex list-none flex-col items-start justify-end gap-4"
               }
             >
-              {navLinks.map((link) => (
-                <li
-                  key={link.id}
-                  className={`${active === link.id ? "text-white" : "text-secondary"} cursor-pointer font-[Poppins] text-base font-medium`}
-                  onClickCapture={() => {
+              {isHome
+                ? navLinks.map((link) => (
+                    <li
+                      key={link.id}
+                      className={`${active === link.id ? "text-white" : "text-secondary"} cursor-pointer font-[Poppins] text-base font-medium`}
+                      onClickCapture={() => {
+                        setToggle(!toggle);
+                        setActive(link.id);
+                      }}
+                    >
+                      <a href={`#${link.id}`}>{t(link.title)}</a>
+                    </li>
+                  ))
+                : null}
+              <li
+                className={`${active === "blog" ? "text-white" : "text-secondary"} cursor-pointer font-[Poppins] text-base font-medium`}
+              >
+                <Link
+                  href={blogHref}
+                  onClick={() => {
                     setToggle(!toggle);
-                    setActive(link.id);
+                    setActive("blog");
                   }}
                 >
-                  <a href={`#${link.id}`}>{t(link.title)}</a>
-                </li>
-              ))}
+                  {t("blog")}
+                </Link>
+              </li>
               <div className={"flex flex-row justify-between gap-4"}>
                 <button
+                  type="button"
                   onClick={() => {
-                    void handleLanguageChange(languages.portuguese);
+                    handleLanguageChange(languages.portuguese);
                   }}
                 >
                   <Image
@@ -163,13 +215,14 @@ const Navbar = () => {
                   />
                 </button>
                 <button
+                  type="button"
                   onClick={() => {
-                    void handleLanguageChange(languages.english);
+                    handleLanguageChange(languages.english);
                   }}
                 >
                   <Image
                     src={usa}
-                    alt={t("country_img")}
+                    alt={t("country_img_en")}
                     width={36}
                     height={36}
                     className={countryImgStyleClass(languages.english.code)}

--- a/app/src/components/Projects.tsx
+++ b/app/src/components/Projects.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { motion } from "framer-motion";
 import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
 import { fadeIn, textVariant } from "../utils/motion.ts";
 import { styles } from "../styles.ts";
 import { projects } from "../constants";
@@ -8,22 +11,38 @@ import { SectionWrapper } from "../hoc";
 import { github } from "../assets";
 import { useTranslation } from "react-i18next";
 import { IProjectCard } from "../utils/types.ts";
+import {
+  DEFAULT_LOCALE,
+  isLocale,
+  Locale,
+  localizedPath,
+} from "../constants/seo";
 
 const ProjectCard = ({
   index,
-  name,
-  description,
+  slug,
+  nameKey,
+  descriptionKey,
   tags,
   image,
   webImg,
   source_code_link,
   demo_link,
   isCaseStudy,
-}: IProjectCard) => {
+  locale,
+}: IProjectCard & { locale: Locale }) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const hasSource = Boolean(source_code_link);
   const hasDemo = Boolean(demo_link);
   const hasLinks = hasSource || hasDemo;
+  const projectHref = localizedPath(locale, `/projects/${slug}`);
+  const detailsLabel =
+    locale === "pt" ? "Ver detalhes do projeto" : "View project details";
+
+  const goToProject = () => {
+    router.push(projectHref);
+  };
 
   return (
     <motion.div
@@ -41,73 +60,94 @@ const ProjectCard = ({
             : "bg-tertiary"
         }`}
       >
-        <div className="relative h-56 w-full shrink-0">
-          <Image
-            src={image}
-            alt={t(name)}
-            fill
-            sizes="(max-width: 640px) 100vw, 360px"
-            className="rounded-2xl object-cover"
-          />
-          {isCaseStudy ? (
-            <div className="absolute left-3 top-3 rounded-md bg-[#915EFF]/90 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-white">
-              {t("case_study_badge")}
+        <div
+          role="link"
+          tabIndex={0}
+          aria-label={`${t(nameKey)} — ${detailsLabel}`}
+          className="flex h-full cursor-pointer flex-col outline-none focus-visible:ring-2 focus-visible:ring-[#915EFF]"
+          onClick={goToProject}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              goToProject();
+            }
+          }}
+        >
+          <div className="relative h-56 w-full shrink-0" style={{ position: "relative" }}>
+            <Image
+              src={image}
+              alt={t(nameKey)}
+              fill
+              sizes="(max-width: 640px) 100vw, 360px"
+              className="rounded-2xl object-cover"
+            />
+            {isCaseStudy ? (
+              <div className="absolute left-3 top-3 rounded-md bg-[#915EFF]/90 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                {t("case_study_badge")}
+              </div>
+            ) : null}
+            {hasLinks ? (
+              <div className="absolute inset-0 m-3 flex justify-end gap-1">
+                {hasSource ? (
+                  <div className="black-gradient flex size-10 items-center justify-center rounded-full">
+                    <a
+                      href={source_code_link}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`${t(nameKey)} source code`}
+                      className="flex size-full items-center justify-center"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <Image
+                        src={github}
+                        alt=""
+                        width={40}
+                        height={40}
+                        className="object-contain"
+                      />
+                    </a>
+                  </div>
+                ) : null}
+                {hasDemo ? (
+                  <div className="flex size-10 items-center justify-center rounded-full">
+                    <a
+                      href={demo_link}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`${t(nameKey)} live demo`}
+                      className="flex size-full items-center justify-center"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <Image
+                        src={webImg}
+                        alt=""
+                        width={40}
+                        height={40}
+                        className="object-contain"
+                      />
+                    </a>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          <div className="mt-5 flex min-h-0 flex-1 flex-col">
+            <h3 className="text-xl font-bold text-white sm:text-2xl">
+              <span className="hover:text-[#915EFF]">{t(nameKey)}</span>
+            </h3>
+            <p className="mt-2 flex-1 text-sm leading-6 text-secondary">
+              {t(descriptionKey)}
+            </p>
+            <p className="mt-3 text-sm font-medium text-[#915EFF]">
+              {detailsLabel} →
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <p key={tag.name} className={`text-sm ${tag.color}`}>
+                  #{tag.name}
+                </p>
+              ))}
             </div>
-          ) : null}
-          {hasLinks ? (
-            <div className="absolute inset-0 m-3 flex justify-end gap-1">
-              {hasSource ? (
-                <div className="black-gradient flex size-10 items-center justify-center rounded-full">
-                  <a
-                    href={source_code_link}
-                    target="_blank"
-                    rel="noreferrer"
-                    aria-label={`${t(name)} source code`}
-                  >
-                    <Image
-                      src={github}
-                      alt=""
-                      width={40}
-                      height={40}
-                      className="cursor-pointer object-contain"
-                    />
-                  </a>
-                </div>
-              ) : null}
-              {hasDemo ? (
-                <div className="flex size-10 items-center justify-center rounded-full">
-                  <a
-                    href={demo_link}
-                    target="_blank"
-                    rel="noreferrer"
-                    aria-label={`${t(name)} live demo`}
-                  >
-                    <Image
-                      src={webImg}
-                      alt=""
-                      width={40}
-                      height={40}
-                      className="cursor-pointer object-contain"
-                    />
-                  </a>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
-        <div className="mt-5 flex min-h-0 flex-1 flex-col">
-          <h3 className="text-xl font-bold text-white sm:text-2xl">
-            {t(name)}
-          </h3>
-          <p className="mt-2 flex-1 text-sm leading-6 text-secondary">
-            {t(description)}
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <p key={tag.name} className={`text-sm ${tag.color}`}>
-                #{tag.name}
-              </p>
-            ))}
           </div>
         </div>
       </ReactParallaxTilt>
@@ -119,6 +159,10 @@ ProjectCard.displayName = "ProjectCard";
 
 const ProjectsSection = () => {
   const { t } = useTranslation();
+  const pathname = usePathname();
+  const localeSegment = pathname.split("/").find(Boolean);
+  const locale: Locale =
+    localeSegment && isLocale(localeSegment) ? localeSegment : DEFAULT_LOCALE;
 
   return (
     <>
@@ -137,8 +181,9 @@ const ProjectsSection = () => {
       <div className={"mt-16 flex flex-wrap items-stretch gap-7"}>
         {projects.map((project, index) => (
           <ProjectCard
-            key={`project-${project.name}`}
+            key={`project-${project.slug}`}
             index={index}
+            locale={locale}
             {...project}
           />
         ))}

--- a/app/src/components/Tech.tsx
+++ b/app/src/components/Tech.tsx
@@ -48,22 +48,28 @@ const TechSection = memo(() => {
 
   const staticIcons = (
     <div className={"flex flex-row flex-wrap justify-center gap-10"}>
-      {technologies.map((tech) => (
-        <div
-          key={tech.name}
-          className={"flex size-28 items-center justify-center rounded-full bg-tertiary/60 p-4"}
-        >
-          <Image
-            src={tech.icon}
-            alt={tech.name}
-            width={72}
-            height={72}
-            className="object-contain"
-            style={{ width: 72, height: 72 }}
-            loading="lazy"
-          />
-        </div>
-      ))}
+      {technologies.map((tech) => {
+        const iconSrc = tech.icon.split("?")[0];
+
+        return (
+          <div
+            key={tech.name}
+            className={
+              "flex size-28 items-center justify-center overflow-hidden rounded-full bg-white/95 p-3"
+            }
+          >
+            <Image
+              src={iconSrc}
+              alt={tech.name}
+              width={72}
+              height={72}
+              className="object-contain"
+              style={{ width: 72, height: 72 }}
+              loading="lazy"
+            />
+          </div>
+        );
+      })}
     </div>
   );
 

--- a/app/src/components/Tech.tsx
+++ b/app/src/components/Tech.tsx
@@ -1,14 +1,19 @@
+"use client";
+
+import Image from "next/image";
 import { technologies } from "../constants";
 import { BallCanvas } from "./canvas";
 import { SectionWrapper } from "../hoc";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useContext, useEffect, useRef, useState } from "react";
+import MobileContext from "../contexts/MobileContext";
 
 const TechSection = memo(() => {
+  const isMobile = useContext(MobileContext);
   const [shouldRenderCanvas, setShouldRenderCanvas] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (shouldRenderCanvas) {
+    if (isMobile || shouldRenderCanvas) {
       return;
     }
 
@@ -39,25 +44,48 @@ const TechSection = memo(() => {
     return () => {
       observer.disconnect();
     };
-  }, [shouldRenderCanvas]);
+  }, [isMobile, shouldRenderCanvas]);
 
-  return (
-    <div ref={containerRef}>
-      {shouldRenderCanvas ? (
-        <BallCanvas technologies={technologies} />
-      ) : (
-        <div className={"flex flex-row flex-wrap justify-center gap-10"}>
-          {technologies.map((tech) => (
-            <div
-              key={tech.name}
-              aria-hidden={true}
-              className={"size-28 animate-pulse rounded-full bg-tertiary/60"}
-            />
-          ))}
+  const staticIcons = (
+    <div className={"flex flex-row flex-wrap justify-center gap-10"}>
+      {technologies.map((tech) => (
+        <div
+          key={tech.name}
+          className={"flex size-28 items-center justify-center rounded-full bg-tertiary/60 p-4"}
+        >
+          <Image
+            src={tech.icon}
+            alt={tech.name}
+            width={72}
+            height={72}
+            className="object-contain"
+            style={{ width: 72, height: 72 }}
+            loading="lazy"
+          />
         </div>
-      )}
+      ))}
     </div>
   );
+
+  let content = staticIcons;
+
+  if (!isMobile) {
+    content = shouldRenderCanvas ? (
+      <BallCanvas technologies={technologies} />
+    ) : (
+      <div className={"flex flex-row flex-wrap justify-center gap-10"}>
+        {technologies.map((tech) => (
+          <div
+            key={tech.name}
+            aria-hidden={true}
+            className={"size-28 animate-pulse rounded-full bg-tertiary/60"}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return <div ref={containerRef}>{content}</div>;
 });
 
 TechSection.displayName = "TechSection";

--- a/app/src/components/canvas/Computers.tsx
+++ b/app/src/components/canvas/Computers.tsx
@@ -17,7 +17,7 @@ const Computer = memo(() => {
         angle={0.12}
         penumbra={1}
         intensity={1}
-        castShadow={true}
+        castShadow={!isMobile}
         shadow-mapSize-width={512}
         shadow-mapSize-height={512}
       />
@@ -39,16 +39,19 @@ const ComputerCanvas = memo(() => {
   return (
     <div className={`${isMobile ? "h-64" : "h-96"} w-full cursor-pointer`}>
       <Canvas
-        frameloop={"demand"}
-        shadows={{ type: THREE.PCFShadowMap }}
+        frameloop="demand"
+        shadows={isMobile ? false : { type: THREE.PCFShadowMap }}
         camera={{ position: [20, 3, 5], fov: 25 }}
-        dpr={[1, 1.5]}
-        gl={{ antialias: false, powerPreference: "high-performance" }}
+        dpr={isMobile ? [1, 1] : [1, 1.5]}
+        gl={{
+          antialias: false,
+          powerPreference: isMobile ? "low-power" : "high-performance",
+        }}
       >
         <Suspense fallback={<CanvasLoader />}>
           <OrbitControls
             enableZoom={false}
-            autoRotate={true}
+            autoRotate={!isMobile}
             enablePan={false}
             maxPolarAngle={Math.PI / 2}
             minPolarAngle={Math.PI / 2}

--- a/app/src/constants/i18n-server.ts
+++ b/app/src/constants/i18n-server.ts
@@ -1,0 +1,18 @@
+import type { Locale } from "./seo";
+import pt from "../assets/locales/translations/pt";
+import en from "../assets/locales/translations/en";
+
+const dictionaries = {
+  pt,
+  en,
+} as const;
+
+export type TranslationKey = keyof typeof pt;
+
+export function getDictionary(locale: Locale) {
+  return dictionaries[locale];
+}
+
+export function translate(locale: Locale, key: TranslationKey): string {
+  return dictionaries[locale][key];
+}

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -10,26 +10,21 @@ import {
   flutter,
   gcp,
   innomotics,
-  internet,
   java,
   javascript,
   kotlin,
   mobile,
-  pokedata,
-  portfolio3d,
   postgre,
   reactjs,
   siemens,
   spring,
   tailwind,
-  iloa,
-  talenthub,
   threejs,
   typescript,
-  videowall,
   vue,
   web,
 } from "../assets";
+
 
 const navLinks = [
   {
@@ -173,132 +168,6 @@ const experiences = [
   },
 ];
 
-const projects = [
-  {
-    name: "project_iloa_name",
-    description: "project_iloa_description",
-    tags: [
-      {
-        name: "Vue",
-        color: "green-text-gradient",
-      },
-      {
-        name: "Java/Spring",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "Azure",
-        color: "pink-text-gradient",
-      },
-      {
-        name: "Enterprise",
-        color: "orange-text-gradient",
-      },
-    ],
-    image: iloa,
-    webImg: internet,
-    isCaseStudy: true,
-  },
-  {
-    name: "project_videowall_name",
-    description: "project_videowall_description",
-    tags: [
-      {
-        name: "Vue",
-        color: "green-text-gradient",
-      },
-      {
-        name: "Java/Spring",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "PostgreSQL",
-        color: "pink-text-gradient",
-      },
-      {
-        name: "Azure",
-        color: "orange-text-gradient",
-      },
-    ],
-    image: videowall,
-    webImg: internet,
-    isCaseStudy: true,
-  },
-  {
-    name: "project_talenthub_name",
-    description: "project_talenthub_description",
-    tags: [
-      {
-        name: "SaaS",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "Multi-tenant",
-        color: "green-text-gradient",
-      },
-      {
-        name: "Web",
-        color: "pink-text-gradient",
-      },
-    ],
-    image: talenthub,
-    webImg: internet,
-    isCaseStudy: true,
-  },
-  {
-    name: "project_4_name",
-    description: "project_4_description",
-    tags: [
-      {
-        name: "Flutter",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "Dart",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "Firebase",
-        color: "orange-text-gradient",
-      },
-      {
-        name: "Riverpod",
-        color: "green-text-gradient",
-      },
-    ],
-    image: pokedata,
-    webImg: internet,
-    source_code_link: "https://github.com/kaiquesimao/new_pokedex_app",
-    demo_link: "https://pokedata.kaique.site",
-  },
-  {
-    name: "project_1_name",
-    description: "project_1_description",
-    tags: [
-      {
-        name: "Next",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "TypeScript",
-        color: "blue-text-gradient",
-      },
-      {
-        name: "Three.js",
-        color: "green-text-gradient",
-      },
-      {
-        name: "Tailwind",
-        color: "pink-text-gradient",
-      },
-    ],
-    image: portfolio3d,
-    webImg: internet,
-    source_code_link: "https://github.com/kaiquesimao/portfolio_3d",
-    demo_link: "https://portfolio.kaique.site",
-  },
-];
-
 const languages = {
   english: {
     nativeName: "English",
@@ -314,7 +183,8 @@ export {
   devStacks,
   technologies,
   experiences,
-  projects,
   navLinks,
   languages,
 };
+
+export {projects} from "./projects";

--- a/app/src/constants/metadata.ts
+++ b/app/src/constants/metadata.ts
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import {
+  absoluteUrl,
+  languageAlternates,
+  Locale,
+  LOCALE_OG,
+  seoByLocale,
+  SITE_NAME,
+  SITE_URL,
+} from "./seo";
+
+type BuildMetadataOptions = {
+  locale: Locale;
+  path?: string;
+  title?: string;
+  description?: string;
+  ogType?: "website" | "article";
+};
+
+export function buildPageMetadata({
+  locale,
+  path = "",
+  title,
+  description,
+  ogType = "website",
+}: BuildMetadataOptions): Metadata {
+  const copy = seoByLocale[locale];
+  const pageTitle = title ?? copy.title;
+  const pageDescription = description ?? copy.description;
+  const canonicalPath = localizedCanonical(locale, path);
+  const url = absoluteUrl(locale, path);
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    keywords: copy.keywords,
+    authors: [{ name: SITE_NAME, url: SITE_URL }],
+    creator: SITE_NAME,
+    alternates: {
+      canonical: canonicalPath,
+      languages: languageAlternates(path),
+    },
+    openGraph: {
+      type: ogType,
+      locale: LOCALE_OG[locale],
+      alternateLocale: Object.values(LOCALE_OG).filter(
+        (value) => value !== LOCALE_OG[locale],
+      ),
+      url,
+      siteName: SITE_NAME,
+      title: pageTitle,
+      description: pageDescription,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description: pageDescription,
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+function localizedCanonical(locale: Locale, path: string): string {
+  if (!path || path === "/") {
+    return `/${locale}`;
+  }
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `/${locale}${normalized}`;
+}

--- a/app/src/constants/projects.ts
+++ b/app/src/constants/projects.ts
@@ -1,0 +1,103 @@
+import {
+  iloa,
+  internet,
+  pokedata,
+  portfolio3d,
+  talenthub,
+  videowall,
+} from "../assets";
+import type { TranslationKey } from "./i18n-server";
+
+export type ProjectRecord = {
+  slug: string;
+  nameKey: TranslationKey;
+  descriptionKey: TranslationKey;
+  tags: { name: string; color: string }[];
+  image: string;
+  webImg: string;
+  source_code_link?: string;
+  demo_link?: string;
+  isCaseStudy?: boolean;
+};
+
+export const projects: ProjectRecord[] = [
+  {
+    slug: "iloa",
+    nameKey: "project_iloa_name",
+    descriptionKey: "project_iloa_description",
+    tags: [
+      { name: "Vue", color: "green-text-gradient" },
+      { name: "Java/Spring", color: "blue-text-gradient" },
+      { name: "Azure", color: "pink-text-gradient" },
+      { name: "Enterprise", color: "orange-text-gradient" },
+    ],
+    image: iloa,
+    webImg: internet,
+    isCaseStudy: true,
+  },
+  {
+    slug: "videowall",
+    nameKey: "project_videowall_name",
+    descriptionKey: "project_videowall_description",
+    tags: [
+      { name: "Vue", color: "green-text-gradient" },
+      { name: "Java/Spring", color: "blue-text-gradient" },
+      { name: "PostgreSQL", color: "pink-text-gradient" },
+      { name: "Azure", color: "orange-text-gradient" },
+    ],
+    image: videowall,
+    webImg: internet,
+    isCaseStudy: true,
+  },
+  {
+    slug: "talenthub",
+    nameKey: "project_talenthub_name",
+    descriptionKey: "project_talenthub_description",
+    tags: [
+      { name: "SaaS", color: "blue-text-gradient" },
+      { name: "Multi-tenant", color: "green-text-gradient" },
+      { name: "Web", color: "pink-text-gradient" },
+    ],
+    image: talenthub,
+    webImg: internet,
+    isCaseStudy: true,
+  },
+  {
+    slug: "pokedata",
+    nameKey: "project_4_name",
+    descriptionKey: "project_4_description",
+    tags: [
+      { name: "Flutter", color: "blue-text-gradient" },
+      { name: "Dart", color: "blue-text-gradient" },
+      { name: "Firebase", color: "orange-text-gradient" },
+      { name: "Riverpod", color: "green-text-gradient" },
+    ],
+    image: pokedata,
+    webImg: internet,
+    source_code_link: "https://github.com/kaiquesimao/new_pokedex_app",
+    demo_link: "https://pokedata.kaique.site",
+  },
+  {
+    slug: "portfolio-3d",
+    nameKey: "project_1_name",
+    descriptionKey: "project_1_description",
+    tags: [
+      { name: "Next", color: "blue-text-gradient" },
+      { name: "TypeScript", color: "blue-text-gradient" },
+      { name: "Three.js", color: "green-text-gradient" },
+      { name: "Tailwind", color: "pink-text-gradient" },
+    ],
+    image: portfolio3d,
+    webImg: internet,
+    source_code_link: "https://github.com/kaiquesimao/portfolio_3d",
+    demo_link: "https://portfolio.kaique.site",
+  },
+];
+
+export function getProjectBySlug(slug: string): ProjectRecord | undefined {
+  return projects.find((project) => project.slug === slug);
+}
+
+export function getProjectSlugs(): string[] {
+  return projects.map((project) => project.slug);
+}

--- a/app/src/constants/seo.ts
+++ b/app/src/constants/seo.ts
@@ -1,0 +1,23 @@
+export const SITE_URL = "https://portfolio.kaique.site";
+
+export const SITE_NAME = "Kaique Simão";
+
+export const PAGE_TITLE = "Kaique Simão | Software Engineer";
+
+export const PAGE_DESCRIPTION =
+  "Software Engineer full-stack — sistemas críticos, SaaS multi-tenant, cloud e experiências web modernas.";
+
+export const SEO_KEYWORDS = [
+  "Software Engineer",
+  "Full-stack",
+  "SaaS",
+  "Cloud",
+  "React",
+  "Next.js",
+  "Kaique Simão",
+];
+
+export const SOCIAL_PROFILES = [
+  "https://github.com/kaiquesimao",
+  "https://www.linkedin.com/in/kaique-simao",
+] as const;

--- a/app/src/constants/seo.ts
+++ b/app/src/constants/seo.ts
@@ -2,22 +2,94 @@ export const SITE_URL = "https://portfolio.kaique.site";
 
 export const SITE_NAME = "Kaique Simão";
 
+export const LOCALES = ["pt", "en"] as const;
+
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "pt";
+
+export const LOCALE_OG: Record<Locale, string> = {
+  pt: "pt_BR",
+  en: "en_US",
+};
+
+export const LOCALE_HTML: Record<Locale, string> = {
+  pt: "pt",
+  en: "en",
+};
+
+export const LOCALE_SCHEMA: Record<Locale, string> = {
+  pt: "pt-BR",
+  en: "en-US",
+};
+
 export const PAGE_TITLE = "Kaique Simão | Software Engineer";
 
-export const PAGE_DESCRIPTION =
-  "Software Engineer full-stack — sistemas críticos, SaaS multi-tenant, cloud e experiências web modernas.";
+export const seoByLocale: Record<
+  Locale,
+  { title: string; description: string; keywords: string[] }
+> = {
+  pt: {
+    title: PAGE_TITLE,
+    description:
+      "Software Engineer full-stack — sistemas críticos, SaaS multi-tenant, cloud e experiências web modernas.",
+    keywords: [
+      "Software Engineer",
+      "Full-stack",
+      "SaaS",
+      "Cloud",
+      "React",
+      "Next.js",
+      "Kaique Simão",
+    ],
+  },
+  en: {
+    title: PAGE_TITLE,
+    description:
+      "Full-stack Software Engineer — mission-critical systems, multi-tenant SaaS, cloud, and modern web experiences.",
+    keywords: [
+      "Software Engineer",
+      "Full-stack",
+      "SaaS",
+      "Cloud",
+      "React",
+      "Next.js",
+      "Kaique Simão",
+    ],
+  },
+};
 
-export const SEO_KEYWORDS = [
-  "Software Engineer",
-  "Full-stack",
-  "SaaS",
-  "Cloud",
-  "React",
-  "Next.js",
-  "Kaique Simão",
-];
+/** @deprecated Prefer seoByLocale[locale].description */
+export const PAGE_DESCRIPTION = seoByLocale.pt.description;
+
+/** @deprecated Prefer seoByLocale[locale].keywords */
+export const SEO_KEYWORDS = seoByLocale.pt.keywords;
 
 export const SOCIAL_PROFILES = [
   "https://github.com/kaiquesimao",
   "https://www.linkedin.com/in/kaique-simao",
 ] as const;
+
+export function isLocale(value: string): value is Locale {
+  return (LOCALES as readonly string[]).includes(value);
+}
+
+export function localizedPath(locale: Locale, path = ""): string {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  if (normalized === "/") {
+    return `/${locale}`;
+  }
+  return `/${locale}${normalized}`;
+}
+
+export function absoluteUrl(locale: Locale, path = ""): string {
+  return `${SITE_URL}${localizedPath(locale, path)}`;
+}
+
+export function languageAlternates(path = ""): Record<string, string> {
+  return {
+    pt: absoluteUrl("pt", path),
+    en: absoluteUrl("en", path),
+    "x-default": absoluteUrl(DEFAULT_LOCALE, path),
+  };
+}

--- a/app/src/content/blog.ts
+++ b/app/src/content/blog.ts
@@ -1,0 +1,284 @@
+import type { Locale } from "../constants/seo";
+
+export type BlogSection = {
+  heading?: string;
+  paragraphs: string[];
+};
+
+export type BlogPost = {
+  slug: string;
+  date: string;
+  locales: Record<
+    Locale,
+    {
+      title: string;
+      description: string;
+      sections: BlogSection[];
+    }
+  >;
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "mission-critical-saas",
+    date: "2026-07-01",
+    locales: {
+      pt: {
+        title: "Do ticket ao ownership: sistemas críticos e SaaS no chão de fábrica digital",
+        description:
+          "Lições de anos construindo software industrial 24/7 e produtos multi-tenant — onde estabilidade, SSO corporativo e domínio de negócio pesam mais que a feature da sprint.",
+        sections: [
+          {
+            paragraphs: [
+              "Minha trajetória como Software Engineer não começou em um CRUD confortável. Foi em produtos usados por times industriais e corporativos, onde uma regressão não é só um bug no Jira: é operação parada, aprovação travada ou painel cego no meio do turno.",
+              "Passei de estagiário a pleno atuando full-stack (Java/Spring, Vue, Angular, React, PostgreSQL, Azure) em contextos mission-critical. Esse texto resume o que essa pressão me ensinou — sem expor regras internas, clientes finais ou detalhes confidenciais dos produtos.",
+            ],
+          },
+          {
+            heading: "Dois tipos de “crítico” que aprendi a distinguir",
+            paragraphs: [
+              "No dia a dia eu convivi com famílias diferentes de sistema. De um lado, ferramentas de governança de projeto: limites de autoridade, aprovações, compliance, questionários e colaboração entre áreas. O risco aqui é processuais — decisão errada, falta de rastreio, fluxo quebrado entre jurídico, financeiro e engenharia.",
+              "Do outro, torres de controle operacionais: painéis, severidade visual, alertas e gestão de ocorrências. O risco é tempo real (ou quase): sinal atrasado vira resposta atrasada. São produtos distintos, mas compartilham a mesma exigência — confiança. Ninguém “espera o hotfix de segunda” quando o negócio roda contínuo.",
+            ],
+          },
+          {
+            heading: "O que muda quando o ambiente é 24/7",
+            paragraphs: [
+              "Feature delivery continua importando, mas deixa de ser o único score. Você passa a pensar em falha controlada, contratos claros entre camadas, autenticação empresarial (SSO / Azure AD) como premissa — não como item de backlog — e em mudanças que não derrubam quem já está logado no meio do processo.",
+              "Na prática, isso significa respeitar o domínio antes da moda da stack. Modelagem relacional que acompanha o negócio, i18n de verdade em produto multilíngue, e frontend que aguenta formulários densos e dashboards de monitoramento sem parecer demo de portfólio.",
+              "Também significa trabalhar com design, produto, negócio e QA no mesmo ciclo. Ownership técnico de pleno não é “fazer sozinho”: é conseguir carregar uma fatia do sistema, antecipar impacto e comunicar risco sem drama nem omissão.",
+            ],
+          },
+          {
+            heading: "SaaS multi-tenant: isolamento não é detalhe de infra",
+            paragraphs: [
+              "Em produtos SaaS multi-tenant, o erro clássico é tratar isolamento de dados e governança de acesso como “fase 2”. Quando o tenant B enxerga cheiro do tenant A — ou quando a UX parece um legado de RH com pele nova — você já perdeu a conversa de arquitetura.",
+              "O que eu levo desse tipo de desafio: multi-tenancy e escalabilidade precisam nascer no desenho. Escalabilidade aqui não é só throughput; é manter o produto evolutivo enquanto várias organizações compartilham o mesmo codebase, com experiência consistente e limites claros.",
+            ],
+          },
+          {
+            heading: "O que um recrutador pode extrair daqui",
+            paragraphs: [
+              "Não estou vendendo buzzwords. Estou descrevendo o tipo de pressão sob a qual eu cresci: full-stack em Java/Spring e frontends modernos, cloud Microsoft/Azure no ecossistema corporativo, produtos onde UX ruim ou API frágil doem de verdade.",
+              "Se você busca alguém que já viu sistemas críticos de perto — e que sabe o que não pode ir para um case público — esse é o perfil. Os detalhes confidenciais ficam no NDA; o julgamento de engenharia, não.",
+            ],
+          },
+        ],
+      },
+      en: {
+        title: "From tickets to ownership: mission-critical systems and SaaS in the digital plant floor",
+        description:
+          "Lessons from years building 24/7 industrial software and multi-tenant products — where stability, enterprise SSO, and domain modeling beat the sprint’s shiny feature.",
+        sections: [
+          {
+            paragraphs: [
+              "My path as a Software Engineer did not start with a cozy CRUD app. It started with products used by industrial and corporate teams, where a regression is not just a Jira bug: it is stalled operations, a blocked approval, or a blind dashboard mid-shift.",
+              "I grew from intern to mid-level working full-stack (Java/Spring, Vue, Angular, React, PostgreSQL, Azure) in mission-critical contexts. This piece captures what that pressure taught me — without exposing internal rules, end customers, or confidential product details.",
+            ],
+          },
+          {
+            heading: "Two kinds of “critical” I learned to separate",
+            paragraphs: [
+              "Day to day I lived with different system families. On one side, project-governance tools: authority limits, approvals, compliance, questionnaires, and cross-team collaboration. The risk is procedural — wrong decisions, missing audit trails, broken handoffs across legal, finance, and engineering.",
+              "On the other, operational control towers: dashboards, visual severity, alerts, and incident handling. The risk is near real time: a late signal becomes a late response. Different products, same requirement — trust. Nobody “waits for Monday’s hotfix” when the business runs continuously.",
+            ],
+          },
+          {
+            heading: "What changes in a 24/7 environment",
+            paragraphs: [
+              "Feature delivery still matters, but it stops being the only scoreboard. You start thinking about controlled failure, clear contracts between layers, enterprise auth (SSO / Azure AD) as a premise — not a backlog item — and changes that do not knock over someone mid-process.",
+              "In practice that means respecting domain before stack fashion. Relational modeling that tracks the business, real i18n in multilingual products, and front ends that survive dense forms and monitoring dashboards without looking like a portfolio demo.",
+              "It also means working with design, product, business, and QA in the same loop. Mid-level technical ownership is not “doing it alone”: it is carrying a slice of the system, anticipating impact, and communicating risk without drama or omission.",
+            ],
+          },
+          {
+            heading: "Multi-tenant SaaS: isolation is not an infra footnote",
+            paragraphs: [
+              "In multi-tenant SaaS, the classic mistake is treating data isolation and access governance as “phase two”. When tenant B can smell tenant A — or the UX still feels like legacy HR with a new skin — you already lost the architecture conversation.",
+              "What I take from that class of problem: multi-tenancy and scalability must be born in the design. Scalability here is not only throughput; it is keeping the product evolvable while many organizations share one codebase, with a consistent experience and clear boundaries.",
+            ],
+          },
+          {
+            heading: "What a recruiter can take from this",
+            paragraphs: [
+              "I am not selling buzzwords. I am describing the pressure I grew under: full-stack Java/Spring and modern front ends, Microsoft/Azure in a corporate ecosystem, products where bad UX or a fragile API actually hurt.",
+              "If you want someone who has seen mission-critical systems up close — and who knows what must stay out of a public case study — that is the profile. Confidential details stay under NDA; engineering judgment does not.",
+            ],
+          },
+        ],
+      },
+    },
+  },
+  {
+    slug: "portfolio-web-3d-performance",
+    date: "2026-07-10",
+    locales: {
+      pt: {
+        title: "3D que contrata: como equilibrei Three.js, SEO e performance neste portfólio",
+        description:
+          "O desafio de um portfólio com WebGL de verdade: impressionar sem matar LCP no mobile, sem sumir do Google e sem virar só um canvas bonito.",
+        sections: [
+          {
+            paragraphs: [
+              "Eu poderia ter feito um portfólio estático elegante. Em vez disso, quis um artefato que mostrasse o mesmo tipo de decisão que eu tomo em produto: presença visual versus orçamento de performance, conteúdo versus efeito, ego de engenharia versus o que um recrutador (e um crawler) realmente precisam.",
+              "Este site — Next.js, React Three Fiber, i18n PT/EN, cases detalhados e deploy em Cloudflare Workers — é o laboratório público dessas trocas.",
+            ],
+          },
+          {
+            heading: "O problema não é “colocar 3D”. É não mentir no primeiro paint",
+            paragraphs: [
+              "Three.js chama atenção. Também é fácil destruir INP/LCP em telefone médio se cada seção abrir um WebGL próprio, se as estrelas do fundo competirem com o LCP, ou se o HTML útil só existir depois do JavaScript.",
+              "A regra que eu usei: o primeiro viewport precisa contar quem eu sou em HTML de verdade. O 3D é reforço, não a única fonte de significado. Crawler e humano com rede ruim ainda merecem a história.",
+            ],
+          },
+          {
+            heading: "Decisões concretas que eu defendia em code review",
+            paragraphs: [
+              "Canvas pesado entra com dynamic import e SSR desligado onde faz sentido. Background de estrelas só em desktop e só depois de idle (requestIdleCallback) — mobile não paga o custo de um céu decorativo.",
+              "Nas esferas de tecnologia, um único Canvas com View do drei em vez de N contextos WebGL. Menos GPU, menos drama de bateria, framing mais previsível.",
+              "SEO não é um plugin no final: metadata por locale, rotas `/pt` e `/en`, hreflang, Open Graph, sitemap, JSON-LD e páginas de projeto com narrativa de case — porque LinkedIn share e Googlebot não executam sua cena GLTF.",
+            ],
+          },
+          {
+            heading: "Conteúdo como parte da performance de carreira",
+            paragraphs: [
+              "Performance web sem substância é benchmark. O outro eixo deste projeto foi transformar experiência industrial (governança, torre de controle, SaaS) e projetos públicos (Flutter, este monorepo) em páginas que um recrutador consegue ler em três minutos — com o que pode ser público e o que fica de fora por respeito a NDA.",
+              "Ou seja: o 3D abre a porta; o texto e a arquitetura de informação fazem a entrevista.",
+            ],
+          },
+          {
+            heading: "Stack e entrega",
+            paragraphs: [
+              "Next.js 16 (App Router), React 19, TypeScript, Tailwind, Framer Motion, Three.js/R3F, i18next, OpenNext + Cloudflare Workers. Formulário de contato no server. CI com lint e type-check.",
+              "O ponto não é a lista de libs. É mostrar que eu consigo cruzar frontend avançado, preocupação com Core Web Vitals e disciplina de produto/SEO no mesmo entregável — o tipo de equilíbrio que também aparece quando o “cliente” é uma operação industrial, só que aqui o deploy é público.",
+            ],
+          },
+        ],
+      },
+      en: {
+        title: "3D that gets you hired: balancing Three.js, SEO, and performance in this portfolio",
+        description:
+          "The challenge of a real WebGL portfolio: impress without killing LCP on mobile, without disappearing from Google, and without becoming just a pretty canvas.",
+        sections: [
+          {
+            paragraphs: [
+              "I could have shipped an elegant static portfolio. Instead I wanted an artifact that shows the same kind of decisions I make in product work: visual presence versus performance budget, content versus effect, engineering ego versus what a recruiter (and a crawler) actually need.",
+              "This site — Next.js, React Three Fiber, PT/EN i18n, detailed case pages, and Cloudflare Workers deploy — is the public lab for those tradeoffs.",
+            ],
+          },
+          {
+            heading: "The problem is not “adding 3D”. It is not lying on first paint",
+            paragraphs: [
+              "Three.js gets attention. It is also easy to destroy INP/LCP on a mid-range phone if every section opens its own WebGL context, if background stars compete with LCP, or if useful HTML only appears after JavaScript.",
+              "The rule I used: the first viewport must explain who I am in real HTML. 3D is reinforcement, not the only source of meaning. Crawlers and humans on bad networks still deserve the story.",
+            ],
+          },
+          {
+            heading: "Concrete decisions I would defend in code review",
+            paragraphs: [
+              "Heavy canvases load via dynamic import with SSR off where it matters. Starfield background only on desktop and only after idle (requestIdleCallback) — mobile should not pay for decorative sky.",
+              "For tech spheres, one shared Canvas with drei Views instead of N WebGL contexts. Less GPU, less battery drama, more predictable framing.",
+              "SEO is not a plugin at the end: per-locale metadata, `/pt` and `/en` routes, hreflang, Open Graph, sitemap, JSON-LD, and project pages with case narrative — because LinkedIn shares and Googlebot will not run your GLTF scene.",
+            ],
+          },
+          {
+            heading: "Content as career performance",
+            paragraphs: [
+              "Web performance without substance is a benchmark. The other axis of this project was turning industrial experience (governance, control tower, SaaS) and public work (Flutter, this monorepo) into pages a recruiter can read in three minutes — with what can be public and what stays out of respect for NDAs.",
+              "In other words: 3D opens the door; writing and information architecture get you the interview.",
+            ],
+          },
+          {
+            heading: "Stack and delivery",
+            paragraphs: [
+              "Next.js 16 (App Router), React 19, TypeScript, Tailwind, Framer Motion, Three.js/R3F, i18next, OpenNext + Cloudflare Workers. Server-side contact form. CI with lint and type-check.",
+              "The point is not the library list. It is showing I can cross advanced front-end work, Core Web Vitals care, and product/SEO discipline in one deliverable — the same balance that shows up when the “customer” is an industrial operation, except here the deploy is public.",
+            ],
+          },
+        ],
+      },
+    },
+  },
+  {
+    slug: "flutter-production-pokedata",
+    date: "2026-07-15",
+    locales: {
+      pt: {
+        title: "Levar Flutter a sério: da ideia à Play Store e à web Wasm",
+        description:
+          "O que aprendi publicando o PokeData de verdade — Android, Firebase, Cloudflare Pages, CI/CD e os trade-offs feios que tutorial não mostra.",
+        sections: [
+          {
+            paragraphs: [
+              "Projeto pessoal também revela engenharia. O PokeData nasceu como Pokédex, mas o desafio que me interessava não era “consumir uma API de Pokémon”: era fechar o ciclo de um produto mobile-first com backend, auth, persistência, loja e web em produção.",
+              "Código aberto, demo em pokedata.kaique.site, app na Play Store. Abaixo, o que doeu de verdade — e o que eu repetiria.",
+            ],
+          },
+          {
+            heading: "Um codebase, duas superfícies hostis",
+            paragraphs: [
+              "Flutter brilha no discurso de multiplataforma. Na prática, Android e Web discordam em auth, headers de segurança, deep links e no custo de Wasm. Eu quis um app que funcionasse bem com o polegar e ainda assim sobrevivesse no browser sem ser um afterthought.",
+              "Riverpod para estado, Firebase Auth + Firestore para identidade e favoritos, modo convidado para reduzir fricção. Google Sign-In no mobile; na web, e-mail/senha — porque Wasm multi-thread com COOP/COEP não combina com o helper de Google Auth do Firebase. Isso não é desculpa: é trade-off documentado e consciente.",
+            ],
+          },
+          {
+            heading: "Produção não é flutter run",
+            paragraphs: [
+              "Secrets fora do git (dart_defines, CI secrets). App Bundle com signing de release. Domínio custom no Cloudflare Pages com redirects de SPA e headers pensados para SharedArrayBuffer. Pipeline que roda analyze e testes em todo push, deploy de produção no master e preview por PR.",
+              "Cada um desses itens é chato. Juntos, são a diferença entre “tenho um projeto Flutter no GitHub” e “eu opero um app”.",
+            ],
+          },
+          {
+            heading: "Por que isso importa na minha narrativa profissional",
+            paragraphs: [
+              "No trabalho eu vivo Java/Spring, Vue e Azure em sistemas industriais. No PokeData eu provei o outro braço: mobile híbrido, Firebase/GCP, Cloudflare e disciplina de release sem time de plataforma me segurando a mão.",
+              "Recrutador que lê só o cargo vê “full-stack industrial”. Quem abre o PokeData vê alguém que também entrega ponta a ponta quando o produto é meu — inclusive as partes sem glamour.",
+            ],
+          },
+        ],
+      },
+      en: {
+        title: "Taking Flutter seriously: from idea to Play Store and Wasm web",
+        description:
+          "What I learned shipping PokeData for real — Android, Firebase, Cloudflare Pages, CI/CD, and the ugly tradeoffs tutorials skip.",
+        sections: [
+          {
+            paragraphs: [
+              "Side projects reveal engineering too. PokeData started as a Pokédex, but the challenge I cared about was not “call a Pokémon API”: it was closing the loop on a mobile-first product with backend, auth, persistence, store, and production web.",
+              "Open source, live at pokedata.kaique.site, on the Play Store. Below is what actually hurt — and what I would repeat.",
+            ],
+          },
+          {
+            heading: "One codebase, two hostile surfaces",
+            paragraphs: [
+              "Flutter shines in multiplatform slides. In practice Android and Web disagree on auth, security headers, deep links, and Wasm cost. I wanted an app that felt right under a thumb and still survived in the browser without being an afterthought.",
+              "Riverpod for state, Firebase Auth + Firestore for identity and favorites, guest mode to cut friction. Google Sign-In on mobile; email/password on web — because multi-thread Wasm with COOP/COEP does not play nice with Firebase’s Google Auth helpers. That is not an excuse: it is a documented, conscious tradeoff.",
+            ],
+          },
+          {
+            heading: "Production is not flutter run",
+            paragraphs: [
+              "Secrets out of git (dart_defines, CI secrets). Release-signed App Bundle. Custom domain on Cloudflare Pages with SPA redirects and headers aimed at SharedArrayBuffer. A pipeline that runs analyze and tests on every push, production deploy on master, and per-PR previews.",
+              "Each item is boring. Together they are the difference between “I have a Flutter repo on GitHub” and “I operate an app”.",
+            ],
+          },
+          {
+            heading: "Why this belongs in my professional story",
+            paragraphs: [
+              "At work I live in Java/Spring, Vue, and Azure on industrial systems. With PokeData I proved the other arm: hybrid mobile, Firebase/GCP, Cloudflare, and release discipline without a platform team holding my hand.",
+              "A recruiter who only reads the job title sees “industrial full-stack”. Someone who opens PokeData sees a person who also ships end-to-end when the product is mine — including the unglamorous parts.",
+            ],
+          },
+        ],
+      },
+    },
+  },
+];
+
+export function getBlogPost(slug: string): BlogPost | undefined {
+  return blogPosts.find((post) => post.slug === slug);
+}
+
+export function getBlogSlugs(): string[] {
+  return blogPosts.map((post) => post.slug);
+}

--- a/app/src/content/case-studies.ts
+++ b/app/src/content/case-studies.ts
@@ -1,0 +1,227 @@
+import type { Locale } from "../constants/seo";
+
+export type CaseStudyCopy = {
+  summary: string;
+  context: string;
+  outcomes: string[];
+  engineering: string[];
+  note: string;
+};
+
+const caseStudies: Record<string, Record<Locale, CaseStudyCopy>> = {
+  iloa: {
+    pt: {
+      summary:
+        "Case empresarial (Innomotics): plataforma Limit of Authority que transforma aprovações e governança de projetos industriais em um fluxo digital único — no lugar de planilhas e processos espalhados entre áreas.",
+      context:
+        "Em projetos de grande porte, limites de autoridade e aprovações atravessam times técnicos, jurídicos, financeiros e de suporte. O desafio é dar visibilidade e rastreabilidade sem perder a rigidez que o negócio exige.",
+      outcomes: [
+        "Centraliza revisões, compliance e questionários em um único ambiente web corporativo",
+        "Conecta áreas de suporte (como procurement e riscos) ao ciclo de decisão do projeto",
+        "Reduz fragmentação operacional: menos handoff informal, mais histórico e clareza de status",
+        "Autenticação empresarial (SSO) alinhada ao ecossistema Microsoft/Azure da companhia",
+      ],
+      engineering: [
+        "Full-stack em monorepo: Vue 3 + TypeScript no frontend e Java/Spring Boot no backend",
+        "Persistência com PostgreSQL e versionamento de schema; cloud Azure para execução e identidade",
+        "Experiência pensada para uso intenso em escritório: formulários complexos, colaboração e geração de documentos",
+        "Produto mission-critical de governança — estabilidade e clareza de fluxo pesam tanto quanto UI",
+      ],
+      note:
+        "Case study interno: sem demo pública nem exposição de regras de negócio, dados de cliente ou detalhes de infraestrutura.",
+    },
+    en: {
+      summary:
+        "Enterprise case study (Innomotics): a Limit of Authority platform that turns industrial project approvals and governance into one digital flow — instead of spreadsheets and scattered handoffs across teams.",
+      context:
+        "On large projects, authority limits and approvals span technical, legal, finance, and support teams. The challenge is visibility and traceability without losing the rigor the business requires.",
+      outcomes: [
+        "Centralizes reviews, compliance, and questionnaires in a single corporate web environment",
+        "Brings support areas (such as procurement and risk) into the project decision cycle",
+        "Cuts operational fragmentation: fewer informal handoffs, clearer status and history",
+        "Enterprise SSO aligned with the company’s Microsoft/Azure identity stack",
+      ],
+      engineering: [
+        "Full-stack monorepo: Vue 3 + TypeScript on the front end and Java/Spring Boot on the back end",
+        "PostgreSQL persistence with schema versioning; Azure for runtime and identity",
+        "Built for heavy office use: complex forms, collaboration, and document generation",
+        "Mission-critical governance product — stability and clear workflows matter as much as UI",
+      ],
+      note:
+        "Internal case study: no public demo and no disclosure of business rules, customer data, or infrastructure details.",
+    },
+  },
+  videowall: {
+    pt: {
+      summary:
+        "Case empresarial (Innomotics): torre de controle (videowall) para operação industrial — painéis que mostram o que está saudável, o que pede atenção e o que exige resposta agora.",
+      context:
+        "Gestores e operadores precisam acompanhar plantas e logística em um só lugar. Informação atrasada ou espalhada vira reação tarde demais; o produto existe para encurtar o caminho entre sinal e ação.",
+      outcomes: [
+        "Dashboards operacionais de unidades industriais e visão de centro de distribuição / logística",
+        "Indicadores com faixas de severidade (ex.: ideal, atenção, crítico) para leitura rápida em videowall",
+        "Alertas parametrizáveis e notificações corporativas para acelerar o acionamento das equipes",
+        "Gestão de ocorrências em Kanban: abrir, atender, resolver — com status visível para o time",
+      ],
+      engineering: [
+        "Frontend Vue 3 + TypeScript com UX orientada a monitoramento contínuo",
+        "Backend Java/Spring Boot, PostgreSQL e autenticação empresarial Microsoft (Entra ID / Azure AD)",
+        "Arquitetura pensada para atualização periódica de indicadores e consumo por múltiplos usuários",
+        "Integrações com fontes operacionais via conectores — sem expor contratos ou sistemas internos",
+      ],
+      note:
+        "Case study interno: sem demo pública; nomes de unidades, regras de alerta e métricas de negócio permanecem confidenciais.",
+    },
+    en: {
+      summary:
+        "Enterprise case study (Innomotics): a control-tower videowall for industrial operations — dashboards that show what is healthy, what needs attention, and what needs action now.",
+      context:
+        "Managers and operators need plants and logistics in one place. Late or scattered information means late response; the product shortens the path from signal to action.",
+      outcomes: [
+        "Operational dashboards for industrial sites plus distribution / logistics visibility",
+        "Severity bands (e.g. healthy, attention, critical) for fast reading on a videowall",
+        "Configurable alerts and corporate notifications to speed up team response",
+        "Kanban-style incident handling: open, own, resolve — with status visible to the team",
+      ],
+      engineering: [
+        "Vue 3 + TypeScript front end tuned for continuous monitoring UX",
+        "Java/Spring Boot back end, PostgreSQL, and Microsoft enterprise SSO (Entra ID / Azure AD)",
+        "Designed for periodic KPI refresh and concurrent operational users",
+        "Operational data via connectors — without exposing internal contracts or systems",
+      ],
+      note:
+        "Internal case study: no public demo; site names, alert rules, and business metrics remain confidential.",
+    },
+  },
+  talenthub: {
+    pt: {
+      summary:
+        "Case empresarial: SaaS multi-tenant para processos internos de talentos e RH — um produto onde isolamento por cliente, escalabilidade e UX web moderna são requisitos de primeira classe.",
+      context:
+        "Plataformas de talentos precisam servir várias organizações no mesmo produto, com dados e fluxos separados, sem parecer um sistema legado de RH.",
+      outcomes: [
+        "Modelo multi-tenant pensado para operação interna e experiência consistente entre clientes",
+        "Fluxos de talentos e operações de RH reunidos numa interface web contemporânea",
+        "Ênfase em escalabilidade e manutenibilidade de um produto SaaS de longo prazo",
+        "Case apresentado em alto nível: o valor está no tipo de problema, não em features confidenciais",
+      ],
+      engineering: [
+        "Arquitetura SaaS multi-tenant (isolamento e governança de acesso como premissas)",
+        "Entrega full-stack com foco em produto web escalável",
+        "Prioridade em experiência de uso e base técnica sustentável — não em demos públicas",
+      ],
+      note:
+        "Detalhes de produto, demos e stack específica do cliente não são públicos neste case.",
+    },
+    en: {
+      summary:
+        "Enterprise case study: multi-tenant SaaS for internal talent and HR workflows — a product where tenant isolation, scalability, and modern web UX are first-class requirements.",
+      context:
+        "Talent platforms must serve multiple organizations in one product, with separated data and flows, without feeling like legacy HR software.",
+      outcomes: [
+        "Multi-tenant model built for internal operations and a consistent experience across customers",
+        "Talent and HR workflows brought together in a contemporary web UI",
+        "Emphasis on scalability and long-term maintainability of a SaaS product",
+        "Presented at a high level: the value is the problem type, not confidential feature lists",
+      ],
+      engineering: [
+        "Multi-tenant SaaS architecture (isolation and access governance as defaults)",
+        "Full-stack delivery focused on a scalable web product",
+        "UX and a sustainable technical base over public demos",
+      ],
+      note:
+        "Product details, demos, and client-specific stack are not public in this case study.",
+    },
+  },
+  pokedata: {
+    pt: {
+      summary:
+        "App Flutter (Android + Web) que transforma a Pokédex em produto real: explorar Pokémon e regiões, favoritar com conta, entrar como convidado — publicado na Play Store e em pokedata.kaique.site.",
+      context:
+        "Muitos demos Flutter param no protótipo. O desafio foi entregar um app mobile-first com backend Firebase, auth, dados persistidos e pipeline de produção até loja e web Wasm — sem tratar web como afterthought.",
+      outcomes: [
+        "Pokédex completa com regiões, favoritos e navegação pensada para mobile",
+        "Autenticação Firebase (e-mail/senha; Google Sign-In no Android) e favoritos no Cloud Firestore",
+        "Modo convidado (“Explorar sem conta”) para reduzir fricção na primeira visita",
+        "Distribuição real: Android (Play Store) + web em domínio próprio com CI/CD",
+      ],
+      engineering: [
+        "Flutter + Dart com Riverpod; um codebase para Android e Web",
+        "Firebase Auth + Firestore; secrets e defines fora do git (dart_defines / CI secrets)",
+        "Build web com Wasm multi-thread, headers COOP/COEP e SPA redirects no Cloudflare Pages",
+        "GitHub Actions: analyze, testes, deploy de produção e previews por PR",
+      ],
+      note:
+        "Projeto público: código em GitHub, demo em pokedata.kaique.site e app na Play Store.",
+    },
+    en: {
+      summary:
+        "Flutter app (Android + Web) that turns a Pokédex into a real product: explore Pokémon and regions, favorite with an account, or browse as a guest — shipped to the Play Store and pokedata.kaique.site.",
+      context:
+        "Many Flutter demos stop at prototypes. The challenge was shipping a mobile-first app with Firebase backend, auth, persisted data, and a production pipeline to store + Wasm web — without treating web as an afterthought.",
+      outcomes: [
+        "Full Pokédex with regions, favorites, and mobile-first navigation",
+        "Firebase Auth (email/password; Google Sign-In on Android) and favorites in Cloud Firestore",
+        "Guest mode (“Explore without an account”) to lower first-visit friction",
+        "Real distribution: Android (Play Store) + web on a custom domain with CI/CD",
+      ],
+      engineering: [
+        "Flutter + Dart with Riverpod; one codebase for Android and Web",
+        "Firebase Auth + Firestore; secrets and defines kept out of git (dart_defines / CI secrets)",
+        "Web build with multi-thread Wasm, COOP/COEP headers, and SPA redirects on Cloudflare Pages",
+        "GitHub Actions: analyze, tests, production deploy, and per-PR previews",
+      ],
+      note:
+        "Public project: source on GitHub, live demo at pokedata.kaique.site, and Play Store release.",
+    },
+  },
+  "portfolio-3d": {
+    pt: {
+      summary:
+        "Este portfólio: landing 3D em Next.js com cena interativa, conteúdo bilíngue, cases detalhados e SEO de verdade — deploy em Cloudflare Workers via OpenNext.",
+      context:
+        "Portfólios 3D costumam ser só efeito visual. Aqui o objetivo foi equilibrar presença (Three.js) com conteúdo indexável, performance em mobile e narrativa de engenharia que um recrutador consiga explorar.",
+      outcomes: [
+        "Hero 3D + seções de about, experiência, stack, projetos e contato num único fluxo",
+        "i18n PT/EN com rotas `/pt` e `/en`, hreflang e metadados por locale",
+        "Páginas de projeto e blog com meta própria, Open Graph e JSON-LD",
+        "Formulário de contato server-side (EmailJS) e deploy edge em portfolio.kaique.site",
+      ],
+      engineering: [
+        "Next.js 16 (App Router) + React 19 + TypeScript + Tailwind CSS 4 + Framer Motion",
+        "Three.js / React Three Fiber com lazy load, stars só em idle/desktop e um Canvas compartilhado nas esferas de tech",
+        "SEO: metadataBase, OG image, robots, sitemap, manifest e structured data",
+        "OpenNext + Cloudflare Workers; CI com lint, type-check e preview/prod",
+      ],
+      note:
+        "Projeto público: você está nele. Código no GitHub e live em portfolio.kaique.site.",
+    },
+    en: {
+      summary:
+        "This portfolio: a 3D Next.js landing with an interactive scene, bilingual content, detailed case pages, and real SEO — deployed to Cloudflare Workers via OpenNext.",
+      context:
+        "3D portfolios often stop at visual flair. The goal here was to balance presence (Three.js) with indexable content, mobile performance, and an engineering narrative recruiters can actually explore.",
+      outcomes: [
+        "3D hero plus about, experience, stack, projects, and contact in one flow",
+        "PT/EN i18n with `/pt` and `/en` routes, hreflang, and per-locale metadata",
+        "Project and blog pages with their own meta, Open Graph, and JSON-LD",
+        "Server-side contact form (EmailJS) and edge deploy at portfolio.kaique.site",
+      ],
+      engineering: [
+        "Next.js 16 (App Router) + React 19 + TypeScript + Tailwind CSS 4 + Framer Motion",
+        "Three.js / React Three Fiber with lazy load, stars only on idle/desktop, and one shared Canvas for tech spheres",
+        "SEO: metadataBase, OG image, robots, sitemap, manifest, and structured data",
+        "OpenNext + Cloudflare Workers; CI with lint, type-check, and preview/prod",
+      ],
+      note:
+        "Public project: you are on it. Source on GitHub and live at portfolio.kaique.site.",
+    },
+  },
+};
+
+export function getCaseStudy(
+  slug: string,
+  locale: Locale,
+): CaseStudyCopy | undefined {
+  return caseStudies[slug]?.[locale];
+}

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -15,13 +15,17 @@ i18n
   .use(initReactI18next)
   .init({
     debug: false,
-    resources: { ...translationResources }, //default namespace is 'translation'
+    resources: { ...translationResources },
     lng: languages.portuguese.code,
     supportedLngs: Object.values(languages).map((lang) => lang.code),
     fallbackLng: languages.portuguese.code,
     nonExplicitSupportedLngs: true,
+    detection: {
+      order: ["path", "htmlTag"],
+      caches: [],
+    },
     interpolation: {
-      escapeValue: false, // not needed for react as it escapes by default
+      escapeValue: false,
     },
   })
   .catch((error) => {

--- a/app/src/utils/types.ts
+++ b/app/src/utils/types.ts
@@ -42,8 +42,9 @@ export interface ExperienceType {
 
 export interface IProjectCard {
   index: number;
-  name: string;
-  description: string;
+  slug: string;
+  nameKey: string;
+  descriptionKey: string;
   tags: { name: string; color: string }[];
   image: string;
   source_code_link?: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { DEFAULT_LOCALE, isLocale, LOCALES } from "./app/src/constants/seo";
 
-export function proxy(request: NextRequest) {
+/**
+ * Locale routing for Cloudflare Workers / OpenNext.
+ * Keep as middleware.ts (Edge): proxy.ts is Node-only in Next 16 and not
+ * supported yet by @opennextjs/cloudflare builds.
+ */
+export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DEFAULT_LOCALE, isLocale, LOCALES } from "./app/src/constants/seo";
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/opengraph-image") ||
+    pathname.startsWith("/icon") ||
+    pathname.startsWith("/apple-icon") ||
+    pathname.startsWith("/manifest") ||
+    pathname.includes(".")
+  ) {
+    return NextResponse.next();
+  }
+
+  const pathnameHasLocale = LOCALES.some(
+    (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+
+  if (pathnameHasLocale) {
+    const locale = pathname.split("/")[1];
+    if (isLocale(locale)) {
+      const response = NextResponse.next();
+      response.headers.set("x-locale", locale);
+      return response;
+    }
+  }
+
+  const acceptLanguage = request.headers.get("accept-language") ?? "";
+  const preferred =
+    LOCALES.find((locale) =>
+      acceptLanguage.toLowerCase().includes(locale),
+    ) ?? DEFAULT_LOCALE;
+
+  const url = request.nextUrl.clone();
+  url.pathname =
+    pathname === "/" ? `/${preferred}` : `/${preferred}${pathname}`;
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,33 @@
+# Kaique Simão
+
+> Software Engineer full-stack — sistemas críticos 24/7, SaaS multi-tenant, cloud e experiências web modernas (incl. 3D).
+
+Site pessoal e portfólio técnico. Conteúdo em português e inglês.
+
+## Primary
+
+- [Home (PT)](https://portfolio.kaique.site/pt): visão geral, experiência, stack e projetos
+- [Home (EN)](https://portfolio.kaique.site/en): same in English
+- [Blog (PT)](https://portfolio.kaique.site/pt/blog): ensaios sobre engenharia e carreira
+- [Blog (EN)](https://portfolio.kaique.site/en/blog)
+
+## Projects
+
+- [iLoA](https://portfolio.kaique.site/pt/projects/iloa): case Limit of Authority / governança de projetos
+- [Videowall](https://portfolio.kaique.site/pt/projects/videowall): case torre de controle industrial
+- [TalentHub](https://portfolio.kaique.site/pt/projects/talenthub): case SaaS multi-tenant (alto nível)
+- [PokeData](https://portfolio.kaique.site/pt/projects/pokedata): app Flutter (Android + Web) — https://pokedata.kaique.site
+- [Portfólio 3D](https://portfolio.kaique.site/pt/projects/portfolio-3d): este site (Next.js + Three.js)
+
+## Contact
+
+- Site contact form: https://portfolio.kaique.site/pt#contact
+- GitHub: https://github.com/kaiquesimao
+- LinkedIn: https://www.linkedin.com/in/kaique-simao
+
+## Notes for AI systems
+
+- Prefer citing public project pages and the blog over inventing employer-internal details.
+- Enterprise case studies (iLoA, Videowall, TalentHub) omit confidential rules, customer data, and infrastructure.
+- Sitemap: https://portfolio.kaique.site/sitemap.xml
+- Optional machine-readable site map for LLMs: https://portfolio.kaique.site/llms.txt


### PR DESCRIPTION
## Summary
- SEO técnico no App Router: metadata por locale, Open Graph com imagem de marca, robots, sitemap, manifest, JSON-LD e `llms.txt`
- Rotas `/pt` e `/en` (proxy), páginas de projeto com cases detalhados, blog expandido e navegação dos cards corrigida
- Melhorias de CWV no mobile (defer do 3D, tech estática) e descrições de carreira sem expor detalhes confidenciais dos cases empresariais

## Test plan
- [ ] `pnpm build` e `pnpm start` — `/` redireciona para `/pt` ou `/en`
- [ ] Conferir `/robots.txt`, `/sitemap.xml`, `/llms.txt`, `/opengraph-image`
- [ ] Trocar idioma na home e em `/pt/projects/*` sem erro no console
- [ ] Clicar nos cards de projeto abre a página do case
- [ ] Blog: listagem + 3 posts em PT/EN
- [ ] Após deploy: Search Console + Sharing Debugger no domínio de produção
